### PR TITLE
A few quick fixes 1 test 2 patches for input crashes

### DIFF
--- a/VariantValidator/modules/exon_numbering.py
+++ b/VariantValidator/modules/exon_numbering.py
@@ -63,6 +63,10 @@ def finds_exon_number(variant, validator):
         start_position = coordinates
         end_position = coordinates
 
+    # remove bracket from uncertain start
+    if start_position.startswith('('):
+        start_position = start_position[1:]
+
     # Create empty output dictionary
     exon_start_end_positions = {}
 

--- a/VariantValidator/modules/format_converters.py
+++ b/VariantValidator/modules/format_converters.py
@@ -95,6 +95,14 @@ def initial_format_conversions(variant, validator, select_transcripts_dict_plus_
         except:
             # Check for common mistakes
             toskip = use_checking.refseq_common_mistakes(variant)
+            if toskip:
+                return True
+            # try again if corrected
+            try:
+                toskip = final_hgvs_convert(variant, validator)
+            except:
+                return True
+        # fail if un-corrected errors persist
         if toskip:
             return True
 

--- a/VariantValidator/modules/use_checking.py
+++ b/VariantValidator/modules/use_checking.py
@@ -18,6 +18,21 @@ def pre_parsing_global_common_mistakes(my_variant):
     This may in fact want to be merged into the later use checking functions in the long term,
     or else may grow to handle more if some of these are converted to post-obj parsing instead
     """
+    # test that it is not just a number or a numeric ID
+    # since numeric ids may contain a : reverse quibble substitutions if otherwise fully numeric
+    # e.g 1:111111 2:435636 12:30 would be treated as appropriate NC_ otherwise
+    if re.match(r'^[\d\s\.,:;\-\+]+$',my_variant.original.strip()):
+        my_variant.quibble = my_variant.original.strip()
+    if re.match(r'\d', my_variant.quibble) and re.match(r'^[\d\s\.,:;\-\+]+$', my_variant.quibble):
+        warning = "InvalidVariantError: VariantValidator operates on variant descriptions, but " +\
+            f'this variant "{my_variant.quibble}" only contains numeric characters (and ' +\
+            "possibly numeric associated punctuation), so can not be analysed. Did you enter this"+\
+            " incorrectly, for example entering the numeric ID of a variant, instead of it`s " +\
+            "description, or else enter just a within-sequence location, without specifying the " +\
+            "actual variation?"
+        my_variant.warnings.append(warning)
+        return True
+
     invalid = my_variant.format_quibble()
     if invalid:
         if re.search(r'\w+:[gcnmrp],', my_variant.quibble):

--- a/VariantValidator/modules/vvMixinCore.py
+++ b/VariantValidator/modules/vvMixinCore.py
@@ -100,12 +100,13 @@ class Mixin(vvMixinConverters.Mixin):
                 batch_queries = json.loads(batch_variant)
             except json.decoder.JSONDecodeError:
                 batch_queries = [batch_variant]
-
+            if isinstance(batch_queries, int):
+                batch_queries = [str(batch_queries)]
             # Turn each variant into a dictionary. The dictionary will be compiled during validation
             self.batch_list = []
             for queries in batch_queries:
-                if isinstance(batch_queries, int):
-                    batch_queries = str(batch_queries)
+                if isinstance(queries, int):
+                    queries = str(queries)
                 queries = queries.strip()
                 query = Variant(queries)
                 self.batch_list.append(query)

--- a/VariantValidator/modules/vvMixinCore.py
+++ b/VariantValidator/modules/vvMixinCore.py
@@ -1179,6 +1179,14 @@ class Mixin(vvMixinConverters.Mixin):
                     variant.primary_assembly_loci = primary_genomic_dicts
                     if hgvs_tx_variant:
                         variant.hgvs_transcript_variant = hgvs_tx_variant
+                else:
+                     for mapping in variant.alt_genomic_loci:
+                        for gennome in mapping:
+                            mapping[gennome]["vcf"] = {
+                                    'chr': None,
+                                    'pos': None,
+                                    'ref': None,
+                                    'alt': None}
                 if not variant.hgvs_transcript_variant and hgvs_tx_variant:
                     variant.hgvs_transcript_variant = hgvs_tx_variant
                 variant.reference_sequence_records = ''

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -31081,6 +31081,14 @@ class TestVariantsAuto(TestCase):
             "tlr": "NP_001015877.1:p.(His185_Gly186del)"
         }
 
+    def test_regress_start_end_order(self):
+        # Test a pair of variants that regressed (but get fixed during later development) due to
+        # getting assigned a start coordinate after their end during processing, which crashes VV.
+        variant = 'chr20:g.63316576A>G'
+        results = self.vv.validate(variant, 'GRCh38','all')
+        variant = 'chrX:g.70259255G>A'
+        results = self.vv.validate(variant, 'GRCh38','all')
+
 # <LICENSE>
 # Copyright (C) 2016-2024 VariantValidator Contributors
 #

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -31089,6 +31089,22 @@ class TestVariantsAuto(TestCase):
         variant = 'chrX:g.70259255G>A'
         results = self.vv.validate(variant, 'GRCh38','all')
 
+    def test_unc_pos_exon_crash(self):
+        # Test for uncertain position variant that caused a crash in exon mapping due to (* start
+        variant = 'NM_000344.4:c.(*3+1_*4-1)del'
+        results = self.vv.validate(variant, 'GRCh38','all').format_as_dict(test=True)
+        assert "NM_000344.4:c.(*3+1_*4-1)del" in results
+        assert results["NM_000344.4:c.(*3+1_*4-1)del"]["primary_assembly_loci"]["grch38"][
+                "hgvs_genomic_description"] ==  "NC_000005.10:g.(70951995_70952438)del"
+        assert results["NM_000344.4:c.(*3+1_*4-1)del"]["primary_assembly_loci"]["grch38"][
+                "vcf"] == {"alt": None,"chr": None,"pos": None,"ref": None }
+        assert results["NM_000344.4:c.(*3+1_*4-1)del"]["alt_genomic_loci"][0]['grch38'][
+                "hgvs_genomic_description"] == "NT_187651.1:g.(500428_500871)del"
+        assert results["NM_000344.4:c.(*3+1_*4-1)del"]["alt_genomic_loci"][0]['grch38'][
+                'vcf'] == {"alt": None,"chr": None,"pos": None,"ref": None }
+
+
+
 # <LICENSE>
 # Copyright (C) 2016-2024 VariantValidator Contributors
 #

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -737,6 +737,38 @@ class TestWarnings(TestCase):
             "NM_032790.2|NM_032790.3|NM_032790.4"
         ]
 
+    def test_numeric_input(self):
+        # Test new more specific warning for numeric input, this could be a truncated VCF derived
+        # format, or a ClinVar Variation ID, or some other miscellaneous numeric flavored typo/
+        # miss-paste, but either way contains nothing not numeric or numeric like punctuation.
+        warning = "InvalidVariantError: VariantValidator operates on variant descriptions, but " +\
+            'this variant "{variant.quibble}" only contains numeric characters (and possibly ' +\
+            "numeric associated punctuation), so can not be analysed. Did you enter this " +\
+            "incorrectly, for example entering the numeric ID of a variant, instead of it`s " +\
+            "description, or else enter just a within-sequence location, without specifying " +\
+            "the actual variation?"
+
+        variant = '1-111425'
+        results = self.vv.validate(variant, 'GRCh38', 'all').format_as_dict(test=True)
+        print(results)
+        print( warning.replace('{variant.quibble}',variant))
+        assert results['validation_warning_1']["validation_warnings"][0] == \
+                warning.replace('{variant.quibble}',variant)
+
+        variant = '7852'
+        results = self.vv.validate(variant, 'GRCh38', 'all').format_as_dict(test=True)
+        assert results['validation_warning_1']["validation_warnings"] == [
+                warning.replace('{variant.quibble}',variant)]
+
+        variant = '12:30'
+        results = self.vv.validate(variant, 'GRCh38', 'all').format_as_dict(test=True)
+        assert results['validation_warning_1']["validation_warnings"] == [
+                warning.replace('{variant.quibble}',variant)]
+
+        variant = '1,000'
+        results = self.vv.validate(variant, 'GRCh38', 'all').format_as_dict(test=True)
+        assert results['validation_warning_1']["validation_warnings"] == [
+                warning.replace('{variant.quibble}',variant)]
 
 class TestVFGapWarnings(TestCase):
 


### PR DESCRIPTION
This pull request adds the extra fixes that where possibly to-be-added to my larger rewrite, since you pulled without feedback I am including them here to put in if you like. Patches include:

1 A test for the previously untested transient failure in the base vv_ensembl_dev_susmi branch, before my changes, that I accidentally fixed in my dev work. This is included to prevent regressions later.
2. A better catch for numeric type inputs, which where still sometimes leaking into the later code and causing crashes, along with a more specific error/warning. I am hoping that the more specific error helps clue the people who seem to be putting in ClinVar IDs or the like, into what we actually take as input. + tests for the same.
3. A fix for uncertain pos variants that end up in the exon_numbering code, + a fix for these variants getting VCF output for the alts when they should not do so (and don't for the main chrs) + a test for both issues.

I don't know whether this is too late to put in before the final merge but it should help reduce spam to the admin account if we do.

If you want a different/better error message for 2 just let me know and I will fix it up.