### PR TITLE
Jfw sql soc and cleanup

### DIFF
--- a/VariantValidator/modules/mappers.py
+++ b/VariantValidator/modules/mappers.py
@@ -52,6 +52,7 @@ def gene_to_transcripts(variant, validator, select_transcripts_dict):
     # use updated position if normalized to a different position
     if g_query.posedit.pos != g_test.posedit.pos:
         variant.hgvs_genomic = g_test
+        variant.hgvs_formatted = g_test
     else:
         variant.hgvs_genomic = g_query
 
@@ -123,7 +124,8 @@ def gene_to_transcripts(variant, validator, select_transcripts_dict):
                 error = 'Mapping unavailable for RefSeqGene ' + str(variant.hgvs_formatted) + \
                         ' using alignment method = ' + validator.alt_aln_method
                 variant.warnings.append(error)
-                variant.hgvs_refseqgene_variant = str(variant.hgvs_genomic)
+                variant.genomic_r = variant.hgvs_formatted
+                variant.refseqgene_variant = variant.hgvs_formatted
                 return True
 
             # Extract data

--- a/VariantValidator/modules/vvMixinInit.py
+++ b/VariantValidator/modules/vvMixinInit.py
@@ -81,14 +81,17 @@ class Mixin:
 
         os.environ['HGVS_SEQREPO_DIR'] = self.seqrepoPath
 
+        psql_host_or_socketfile = config['postgres']['host'].replace('/','%2F')
+
         os.environ['UTA_DB_URL'] = "postgresql://%s:%s@%s:%s/%s/%s" % (
             config["postgres"]["user"],
             config["postgres"]["password"],
-            config['postgres']['host'],
+            psql_host_or_socketfile,
             config['postgres']['port'],
             config['postgres']['database'],
             config['postgres']['version']
         )
+
         self.utaPath = os.environ.get('UTA_DB_URL')
 
         self.dbConfig = {
@@ -99,6 +102,9 @@ class Mixin:
             'database': config["mysql"]["database"],
             'raise_on_warnings': True
         }
+        mysql_unix_socket = config.get('mysql','unix_socket',fallback=False)
+        if mysql_unix_socket:
+            self.dbConfig["unix_socket"] = mysql_unix_socket
         # Create database access objects
         self.db = Database(self.dbConfig)
         db_version = self.db.get_db_version()

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -208,18 +208,21 @@ class TestConfigValues(unittest.TestCase):
         self.assertEqual(self.config['mysql']['password'], vv.dbConfig['password'])
         self.assertEqual(self.config['mysql']['host'], vv.dbConfig['host'])
         self.assertEqual(self.config['mysql']['database'], vv.dbConfig['database'])
+        if 'unix_socket' in vv.dbConfig:
+            self.assertEqual(self.config['mysql']['unix_socket'], vv.dbConfig['unix_socket'])
 
         self.assertEqual(vv.seqrepoPath,
                          os.path.join(self.config['seqrepo']['location'], self.config['seqrepo']['version']))
-
-        self.assertEqual(vv.utaPath, "postgresql://%s:%s@%s:%s/%s/%s" % (
+        host_or_socketfile = self.config['postgres']['host'].replace('/','%2F')
+        uta_path = "postgresql://%s:%s@%s:%s/%s/%s" % (
             self.config["postgres"]["user"],
             self.config["postgres"]["password"],
-            self.config['postgres']['host'],
+            host_or_socketfile,
             self.config['postgres']['port'],
             self.config['postgres']['database'],
             self.config['postgres']['version']
-        ))
+        )
+        self.assertEqual(vv.utaPath, uta_path)
 
         self.assertEqual(vv.entrez_email, self.config['Entrez']['email'])
         if self.config['Entrez']['api_key'] == 'YOUR_API_KEY':

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -31165,6 +31165,29 @@ class TestVariantsAuto(TestCase):
             "tlr": "NP_060767.2:p.(Leu6AlafsTer111)"
         }
 
+    def test_rsg_not_in_transcript(self):
+        # test that RSG inputs outside of transcripts don't fail, the use some otherwise
+        # untested RSG specific code paths, including ensuring intergenic RSG keep their
+        # normalisation (G del in a GG leads to 500->501)
+        variant = 'NG_029236.1:g.500del'
+        results = self.vv.validate(variant, 'GRCh38','all').format_as_dict(test=True)
+        assert results["flag"] == "intergenic"
+        assert "intergenic_variant_1" in results
+        assert results["intergenic_variant_1"]["gene_symbol"] == "RGS6"
+
+        assert results["intergenic_variant_1"]["gene_ids"]["hgnc_id"] == "HGNC:10002"
+        assert results["intergenic_variant_1"]["gene_ids"]["entrez_gene_id"] == "9628"
+        assert results["intergenic_variant_1"]["gene_ids"]["ucsc_id"] == "uc001xmx.5"
+        assert results["intergenic_variant_1"]["hgvs_refseqgene_variant"] == "NG_029236.1:g.501del"
+
+        assert results["intergenic_variant_1"]["reference_sequence_records"] == {
+            "refseqgene": "https://www.ncbi.nlm.nih.gov/nuccore/NG_029236.1" }
+
+        assert results["intergenic_variant_1"]["validation_warnings"] == [
+            "No transcripts found that fully overlap the described variation in the genomic sequence",
+            "Mapping unavailable for RefSeqGene NG_029236.1:g.501delG using alignment method = splign"
+        ]
+
 # <LICENSE>
 # Copyright (C) 2016-2025 VariantValidator Contributors
 #


### PR DESCRIPTION
Add the ability to use UNIX socket files for both My and PostgreSQL. Also add a fix for a rare failing input type and test that it is non-crashing and normalises correctly.  The socket file fix relies on https://github.com/openvar/vv_hgvs/pull/12 for pSQL.