### PR TITLE
Jfw lovd tweak2

### DIFF
--- a/VariantValidator/modules/format_converters.py
+++ b/VariantValidator/modules/format_converters.py
@@ -100,9 +100,14 @@ def initial_format_conversions(variant, validator, select_transcripts_dict_plus_
             # try again if corrected
             try:
                 toskip = final_hgvs_convert(variant, validator)
-            except:
+            except vvhgvs.exceptions.HGVSParseError as err:
+                variant.warnings.append("HgvsSyntaxError: " + str(err))
                 return True
-        # fail if un-corrected errors persist
+            except vvhgvs.exceptions.HGVSError as err:
+                variant.warnings.append(f"HgvsParserError: Unknown error during"
+                                        "reading of variant {variant.quibble}")
+                return True
+        # fail if un-corrected errors persist (warning should already have been generated)
         if toskip:
             return True
 

--- a/VariantValidator/modules/format_converters.py
+++ b/VariantValidator/modules/format_converters.py
@@ -137,11 +137,17 @@ def final_hgvs_convert(variant,validator):
         posedit = validator.hp.parse_p_posedit(posedit)
     elif var_type == 'r':
         if 'T' in posedit:
-            e = 'The IUPAC RNA alphabet dictates that RNA variants must use '\
+            e = 'The IUPAC RNA alphabet dictates that RNA variants must use '+\
                     'the character u in place of t'
             variant.warnings.append(e)
             return True
         posedit = validator.hp.parse_r_posedit(posedit)
+    else:
+        e = "VariantSyntaxError: The detected variant sequence type of "+\
+                f"{var_type} ' was not one of the allowed HGVS type "+\
+                "characters of c, g, m, n, p, or r"
+        variant.warnings.append(e)
+        return True
 
     variant.quibble = vvhgvs.sequencevariant.SequenceVariant(
             ac = seq_ac,

--- a/VariantValidator/modules/vvMixinCore.py
+++ b/VariantValidator/modules/vvMixinCore.py
@@ -428,6 +428,12 @@ class Mixin(vvMixinConverters.Mixin):
                                                                              "pos": None,
                                                                              "ref": None,
                                                                              "alt": None},}}
+                    if type(my_variant.quibble) is str:
+                        lovd_response = lovd_api.lovd_syntax_check(my_variant.original.strip(),
+                                                                   do_lovd_check=self.lovd_syntax_check)
+                        if "lovd_api_error" not in lovd_response.keys():
+                            my_variant.output_type_flag = 'warning'
+                            my_variant.lovd_syntax_check = lovd_response
                     if toskip:
                         continue
 
@@ -680,7 +686,7 @@ class Mixin(vvMixinConverters.Mixin):
                         my_variant.warnings.append(error)
                         exc_type, exc_value, last_traceback = sys.exc_info()
                         logger.error(str(exc_type) + " " + str(exc_value))
-                        raise # Note, John, would this be better as a continue. Would stop batch jobs falling over
+                        raise
 
             # Outside the for loop
             ######################

--- a/VariantValidator/modules/vvMixinCore.py
+++ b/VariantValidator/modules/vvMixinCore.py
@@ -695,7 +695,10 @@ class Mixin(vvMixinConverters.Mixin):
             by_order = sorted(self.batch_list, key=lambda x: x.order)
 
             for variant in by_order:
-                logger.debug("Formatting variant " + variant.quibble.format({'p_3_letter':False}))
+                if type(variant.quibble) is str:
+                    logger.debug(f"Formatting variant {variant.quibble}")
+                else:
+                    logger.debug("Formatting variant " + variant.quibble.format({'p_3_letter':False}))
                 if not variant.write:
                     continue
 


### PR DESCRIPTION
Pull a basic fallback for the error catching in the worst case on variant parsing, this was missed during the initial hgvs string quibble to hgvs object conversion. 

This adds an additional place where we call LOVD, if set to do so, for the cases where the input failed to parse but we caught the error, Otherwise LOVD would not get called for these bad inputs after the fixes went in.