### PR TITLE
Jfw vf rel speedup

### DIFF
--- a/VariantValidator/modules/liftover.py
+++ b/VariantValidator/modules/liftover.py
@@ -21,6 +21,7 @@ vvhgvs.global_config.formatting.max_ref_length = 1000000
 
 logger = logging.getLogger(__name__)
 
+LO_CACHE = {}
 
 def mystr(hgvs_nucleotide):
     hgvs_nucleotide_refless = hgvs_nucleotide.format({'max_ref_length': 0})
@@ -340,7 +341,11 @@ def liftover(hgvs_genomic, build_from, build_to, hn, reverse_normalizer, evm, va
     # The structure of the following code comes from VV pymod, so need to create a list
     genome_builds = [build_to]
 
-    lo = LiftOver(lo_from, lo_to)
+    if lo_from not in LO_CACHE:
+        LO_CACHE[lo_from] = {}
+    if lo_to not in LO_CACHE[lo_from]:
+         LO_CACHE[lo_from][lo_to] = LiftOver(lo_from, lo_to)
+    lo = LO_CACHE[lo_from][lo_to]
 
     # Fix the GRC CHR
     if from_vcf[from_set].startswith('chr'):
@@ -472,7 +477,12 @@ def liftover(hgvs_genomic, build_from, build_to, hn, reverse_normalizer, evm, va
                     continue
 
                 # Now try map back
-                lo = LiftOver(lo_to, lo_from)
+                if lo_to not in LO_CACHE:
+                    LO_CACHE[lo_to] = {}
+                if lo_from not in LO_CACHE[lo_to]:
+                    LO_CACHE[lo_to][lo_from] = LiftOver(lo_to, lo_from)
+                lo = LO_CACHE[lo_to][lo_from]
+
                 # Lift back
                 liftback_list = lo.convert_coordinate(chrom, pos)
 

--- a/VariantValidator/modules/vvDBGet.py
+++ b/VariantValidator/modules/vvDBGet.py
@@ -118,9 +118,22 @@ class Mixin(vvDBInit.Mixin):
                 "WHERE hgncSymbol = '%s'" % gene_symbol
         return self.execute_all(query)
 
-    def get_g_to_g_info(self):
+    def get_g_to_g_info(self, rsg_id=None, gen_id=None, start=None, end=None):
+        """
+        Return a set of RSG to genome mapping data.
+        Can be all such mappings or can be limited to either data for a specific
+        RSG or for a specific genomic ref id, and optional location.
+        """
         query = "SELECT refSeqGeneID, refSeqChromosomeID, startPos, endPos, orientation, hgncSymbol, " \
                 "genomeBuild FROM refSeqGene_loci"
+        if rsg_id:
+            query = query + f" WHERE refSeqGeneID='{rsg_id}' "
+        elif gen_id:
+            query = query + f" WHERE refSeqChromosomeID='{gen_id}' "
+            if start:
+                query = query + f"AND startPos <= {str(start)} "
+            if end:
+                query = query + f"AND endPos >= {str(end)} "
         return self.execute_all(query)
 
     def get_all_transcript_id(self):

--- a/VariantValidator/modules/vvMixinConverters.py
+++ b/VariantValidator/modules/vvMixinConverters.py
@@ -2389,7 +2389,10 @@ class Mixin(vvMixinInit.Mixin):
         rsg_data_set = []
 
         # Recover table from MySql
-        all_info = self.db.get_g_to_g_info()
+        all_info = self.db.get_g_to_g_info(
+                gen_id=chr_ac,
+                start=chr_start_pos,
+                end=chr_end_pos)
         for line in all_info:
             # Logic to identify the correct RefSeqGene
             rsg_data = {}
@@ -2524,7 +2527,7 @@ class Mixin(vvMixinInit.Mixin):
         chr_data_set = []
 
         # Recover table from MySql
-        all_info = self.db.get_g_to_g_info()
+        all_info = self.db.get_g_to_g_info(rsg_id=rsg_ac)
 
         for line in all_info:
             # Logic to identify the correct RefSeqGene


### PR DESCRIPTION
A couple of speedups found while testing the performance of the VF code, this speeds up the processing of intergenic variants, particularly if  more than one is being tested by the same object/script. For the test variant it reduces a 4.7 second variant to less than 0.7 seconds, once the cache is filled, which happens fully the first time a intergenic variant is found (this fits nicely with our object pool system on the server).