### PR TITLE
Fixes for speed +robustness

### DIFF
--- a/VariantValidator/modules/format_converters.py
+++ b/VariantValidator/modules/format_converters.py
@@ -28,10 +28,6 @@ def initial_format_conversions(variant, validator, select_transcripts_dict_plus_
     if toskip:
         return True
 
-    toskip = vcf2hgvs_stage3(variant, validator)
-    if toskip:
-        return True
-
     toskip = gene_symbol_catch(variant, validator, select_transcripts_dict_plus_version)
     if toskip:
         return True
@@ -231,91 +227,28 @@ def vcf2hgvs_stage2(variant, validator):
     LRGs and LRG_ts also need to be assigned the correct reference sequence identifier.
     The LRG ID data ia stored in the VariantValidator MySQL database.
     The reference sequence type is also assigned.
+    Now updated to also handle <Chr16>(hg38):g.2099572TC>T, or NM_(GRCh3*) (or
+    worse NC_(GRCh3*), type variant descriptions.
     """
     skipvar = False
-    if (re.search(r'\w+:', variant.quibble) or re.search(r'\w+\(\w+\):', variant.quibble)) and not \
-            (re.search(r'\w+:[gcnmrpoGCNMRPO]\.', variant.quibble) or re.search(r'\w+\(\w+\):[gcnmrpoGCNMRPO]\.',
-                                                                              variant.quibble)):
-        if re.search(r'\w+:[gcnmrpo]', variant.quibble) and not re.search(r'\w+:[gcnmrpo]\.', variant.quibble):
-            # Missing dot
-            pass
+    seq_id_part, _sep, type_posedit = variant.quibble.partition(':')
+    var_type, _sep, posedit = type_posedit.partition('.')
+    # We used to target variant descriptions without types here, and then move on to user input like
+    # <Chr16>:g. in the next stage, but we need to start by fixing the reference identifier first
+    # either way.
+    # first abort on un-handleable types i.e no ':' and bad 'type' with no '.'
+    if not type_posedit:
+        if re.search(r'[gcnmrp]\.', variant.quibble):
+            error = 'Unable to identify a colon (:) in the variant description %s. A colon is required in HGVS variant ' \
+                    'descriptions to separate the reference accession from the reference type i.e. <accession>:<type>. ' \
+                    'e.g. :c.' % variant.quibble
+            variant.warnings.append(error)
+            logger.warning(error)
+            skipvar = True
+            return skipvar
         else:
-            try:
-                if 'GRCh37' in variant.quibble or 'hg19' in variant.quibble:
-                    variant.primary_assembly = 'GRCh37'
-                    validator.selected_assembly = 'GRCh37'
-                    variant.format_quibble()
-                elif 'GRCh38' in variant.quibble or 'hg38' in variant.quibble:
-                    variant.primary_assembly = 'GRCh38'
-                    validator.selected_assembly = 'GRCh38'
-                    variant.format_quibble()
-                # Remove all content in brackets
-                input_list = variant.quibble.split(':')
-                pos_ref_alt = str(input_list[1])
-                position_and_edit = input_list[1]
-                if not re.match(r'N[CGTWMRP]_', variant.quibble) and not re.match(r'LRG_', variant.quibble):
-                    chr_num = str(input_list[0])
-                    chr_num = chr_num.upper().strip()
-                    if re.match('CHR', chr_num):
-                        chr_num = chr_num.replace('CHR', '')
-                    # Use selected assembly
-                    accession = seq_data.to_accession(chr_num, validator.selected_assembly)
-                    if accession is None:
-                        variant.warnings.append(chr_num + ' is not part of genome build ' + validator.selected_assembly)
-                        logger.warning(chr_num + ' is not part of genome build ' + validator.selected_assembly)
-                        skipvar = True
-                else:
-                    accession = input_list[0]
-                if '>' in variant.quibble:
-                    if 'del' in variant.quibble:
-                        pos = re.match(r'\d+', pos_ref_alt)
-                        position = pos.group(0)
-                        old_ref, old_alt = pos_ref_alt.split('>')
-                        old_ref = old_ref.replace(position, '')
-                        position = int(position) - 1
-                        required_base = validator.sf.fetch_seq(accession, start_i=position - 1, end_i=position)
-                        ref = required_base + old_ref
-                        alt = required_base
-                        position_and_edit = str(position) + ref + '>' + alt
-                    elif 'ins' in variant.quibble:
-                        pos = re.match(r'\d+', pos_ref_alt)
-                        position = pos.group(0)
-                        old_ref, old_alt = pos_ref_alt.split('>')
-                        # old_ref = old_ref.replace(position, '')
-                        position = int(position) - 1
-                        required_base = validator.sf.fetch_seq(accession, start_i=position - 1, end_i=position)
-                        ref = required_base
-                        alt = required_base + old_alt
-                        position_and_edit = str(position) + ref + '>' + alt
-
-                # Assign reference sequence type
-                if accession in ["NC_012920.1", "NC_001807.4"]:
-                    ref_type = ":m."
-                else:
-                    ref_type = validator.db.ref_type_assign(accession)
-
-                # Sort LRG formatting
-                if re.match('LRG_', accession):
-                    if ref_type == ':g.':
-                        accession = validator.db.get_refseq_id_from_lrg_id(accession)
-                    else:
-                        accession = validator.db.get_refseq_transcript_id_from_lrg_transcript_id(accession)
-                else:
-                    accession = accession
-                variant.quibble = str(accession) + ref_type + str(position_and_edit)
-
-            except Exception as e:
-                logger.debug("Except passed, %s", e)
-
-    # Descriptions lacking the colon : or the dot .
-    if re.search(r'[gcnmrp]\.', variant.quibble) and not re.search(r':[gcnmrp]\.', variant.quibble):
-        error = 'Unable to identify a colon (:) in the variant description %s. A colon is required in HGVS variant ' \
-                'descriptions to separate the reference accession from the reference type i.e. <accession>:<type>. ' \
-                'e.g. :c.' % variant.quibble
-        variant.warnings.append(error)
-        logger.warning(error)
-        skipvar = True
-    elif re.search(r':[gcnmrp]', variant.quibble) and not re.search(r':[gcnmrp]\.', variant.quibble):
+            return False # do we want to full abort on this yet?
+    if type_posedit and not posedit and type_posedit[:1].lower() in ['g','c','n','m','r','p']:
         error = 'Unable to identify a dot (.) in the variant description %s following the reference sequence ' \
                 'type (g,c,n,r, or p). A dot is required in HGVS variant ' \
                 'descriptions to separate the reference type from the variant position i.e. <accession>:<type>. ' \
@@ -323,73 +256,127 @@ def vcf2hgvs_stage2(variant, validator):
         variant.warnings.append(error)
         logger.warning(error)
         skipvar = True
-    elif re.search(r':[GCNMRPO]\.', variant.quibble):
+
+    if posedit and var_type in ['G','C','N','M','R','P','O']:
         error = 'Reference type incorrectly stated in the variant description %s ' \
                 'Valid types are g,c,n,r, or p' % variant.quibble
         variant.warnings.append(error)
         logger.warning(error)
-        match = re.search(r':[GCNMRPO]\.', variant.quibble)[0]
-        variant.quibble = variant.quibble.replace(match, match.lower())
+        var_type = var_type.lower()
 
-    # Ambiguous chr reference
-    logger.debug("Completed VCF-HVGS step 2 for %s", variant.quibble)
-    return skipvar
-
-
-def vcf2hgvs_stage3(variant, validator):
-    """
-    VCF2HGVS conversion step 3 is similar to step 2 but handles
-    formats like Chr16:g.2099572TC>T which are provided by Alamut and other
-    software
-    """
-    skipvar = False
-    if (re.search(r'\w+:[gcnmrpGCMNRP]\.', variant.quibble) or re.search(r'\w+\(\w+\):[gcnmrpGCMNRP]\.',
-                                                                         variant.quibble)) \
-            and not re.match(r'N[CGTWMRP]_', variant.quibble):
-
-        # Take out lowercase Accession characters
-        lower_cased_list = variant.quibble.split(':')
-        if re.search('LRG', lower_cased_list[0], re.IGNORECASE):
-            lower_case_accession = lower_cased_list[0]
-            lower_case_accession = lower_case_accession.replace('l', 'L')
-            lower_case_accession = lower_case_accession.replace('r', 'R')
-            lower_case_accession = lower_case_accession.replace('g', 'G')
+    # now check for and remove GRC/hg genome builds
+    specifed_ref = False
+    upper_seq_id_part = seq_id_part.upper()
+    if 'GRCHh37' in upper_seq_id_part or 'HG19' in upper_seq_id_part:
+        specifed_ref = 'GRCh37'
+    elif 'GRCH38' in upper_seq_id_part or 'HG38' in upper_seq_id_part:
+        specifed_ref = 'GRCh38'
+    if specifed_ref:
+        if validator.selected_assembly and validator.selected_assembly != specifed_ref:
+            variant.warnings.append(
+                    specifed_ref + ' from ' + seq_id_part +
+                    ' does not match the selected genome build of '
+                    + validator.selected_assembly)
+            return True # return skipvar
+        if variant.primary_assembly and variant.primary_assembly != specifed_ref:
+            variant.warnings.append(
+                    specifed_ref + ' from ' + seq_id_part +
+                    ' does not match the selected genome build of '
+                    + validator.selected_assembly)
+            return True # return skipvar
+        if not validator.selected_assembly:
+            variant.selected_assembly = specifed_ref
+        if not variant.primary_assembly:
+            variant.primary_assembly = specifed_ref
+        specifed_ref = r'\(*' + specifed_ref + r'\)*'
+        replace = re.compile(specifed_ref, re.IGNORECASE)
+        seq_id_part = replace.sub('', seq_id_part)
+        upper_seq_id_part = seq_id_part.upper()
+    # now fix case, all non LRG Ref name characters should be upper case
+    # LRG_ has t as a special case but gene symbols are fine in upper case too
+    if 'LRG' in upper_seq_id_part:
+        if 'l' in seq_id_part or 'r' in seq_id_part or 'g' in seq_id_part:
+            seq_id_part = seq_id_part.replace('l', 'L')
+            seq_id_part = seq_id_part.replace('r', 'R')
+            seq_id_part = seq_id_part.replace('g', 'G')
+    else:
+        seq_id_part = upper_seq_id_part
+    # finally detect any non N._ or ENST type variants, if they are chr types replace the chr
+    # we used to detect gene symbols in vcf2hgvs_stage3 but this is immediately followed by
+    # the gene symbol catching step, and so is redundant
+    if seq_id_part[:3] in ['NC_','NG_','NT_','NW_','NM_','NR_','NP_'] or seq_id_part[:4] in ['ENST','LRG_']:
+        accession = seq_id_part
+    elif seq_id_part.startswith('LRG_'):
+        # For now preserve LRG_ in non vcf type inputs, this may want changing later but that means
+        # test updates too.
+        if var_type:
+            accession = seq_id_part
+        elif 't' in seq_id_part:#var_type == 'g':
+            accession = validator.db.get_refseq_transcript_id_from_lrg_transcript_id(seq_id_part)
         else:
-            lower_case_accession = lower_cased_list[0]
-            lower_case_accession = lower_case_accession.upper()
-        variant.quibble = ''.join(lower_cased_list[1:])
-        variant.quibble = lower_case_accession + ':' + variant.quibble
-        if 'LRG_' not in variant.quibble and 'ENS' not in variant.quibble and not re.match('N[MRPC]_', variant.quibble):
-            try:
-                if re.search('GRCh37', variant.quibble, re.IGNORECASE) or \
-                        re.search('hg19', variant.quibble, re.IGNORECASE):
-                    variant.primary_assembly = 'GRCh37'
-                    validator.selected_assembly = 'GRCh37'
-                    variant.format_quibble()
-                if re.search('GRCh38', variant.quibble, re.IGNORECASE) or \
-                        re.search('hg38', variant.quibble, re.IGNORECASE):
-                    variant.primary_assembly = 'GRCh38'
-                    validator.selected_assembly = 'GRCh38'
-                    variant.format_quibble()
-                input_list = variant.quibble.split(':')
-                query_a_symbol = input_list[0]
-                is_it_a_gene = validator.db.get_hgnc_symbol(query_a_symbol)
-                if is_it_a_gene == 'none':
-                    position_and_edit = input_list[1]
-                    chr_num = str(input_list[0])
-                    chr_num = chr_num.upper().strip()
-                    if re.match('CHR', chr_num):
-                        chr_num = chr_num.replace('CHR', '')  # Use selected assembly
-                    accession = seq_data.to_accession(chr_num, validator.selected_assembly)
-                    if accession is None:
-                        variant.warnings.append(chr_num + ' is not part of genome build ' + validator.selected_assembly)
-                        logger.warning(chr_num + ' is not part of genome build ' + validator.selected_assembly)
-                        skipvar = True
-                    variant.quibble = str(accession) + ':' + str(position_and_edit)
-            except Exception as e:
-                logger.debug("Except passed, %s", e)
+            accession = validator.db.get_refseq_id_from_lrg_id(seq_id_part)
+    else:
+        chr_in = False
+        if seq_id_part.startswith('CHR'):
+            seq_id_part = seq_id_part[3:]
+            chr_in = True
+        accession = seq_data.to_accession(seq_id_part, variant.primary_assembly)
+        # we limit full erroring out to variants without specified type as they are presumed to be VCF type
+        # and so not valid as gene symbols, but just skip otherwise this preserves the old behaviour.
+        # Also hard fail if the var started with chr but none was found, may also want to hard fail for
+        # non c/t types or at least for g
+        if accession is None and (chr_in or not posedit):
+            variant.warnings.append(seq_id_part + ' is not part of genome build ' + validator.selected_assembly)
+            logger.warning(seq_id_part + ' is not part of genome build ' + validator.selected_assembly)
+            skipvar = True
+            return skipvar
+        elif accession is None: # non vcf type failure
+            accession = seq_id_part
+        # we did use 'is_it_a_gene = validator.db.get_hgnc_symbol(query_a_symbol)' and 'if is_it_a_gene == "none":'
+        # in stage 3, but should now force a failure in gene symbol catch step instead.
 
-    logger.debug("Completed VCF-HGVS step 3 for %s", variant.quibble)
+    # finally fix posedit if we have a VCF style input (i.e. no '.' split type)
+    if not posedit:
+        posedit = var_type
+        if '>' in posedit:
+            if 'del' in posedit:
+                pos = re.match(r'\d+', posedit)
+                position = pos.group(0)
+                old_ref, old_alt = posedit.split('>')
+                old_ref = old_ref.replace(position, '')
+                position = int(position) - 1
+                required_base = validator.sf.fetch_seq(accession, start_i=position - 1, end_i=position)
+                ref = required_base + old_ref
+                alt = required_base
+                posedit= str(position) + ref + '>' + alt
+            elif 'ins' in posedit:
+                pos = re.match(r'\d+', posedit)
+                position = pos.group(0)
+                old_ref, old_alt = posedit.split('>')
+                # old_ref = old_ref.replace(position, '')
+                position = int(position) - 1
+                required_base = validator.sf.fetch_seq(accession, start_i=position - 1, end_i=position)
+                ref = required_base
+                alt = required_base + old_alt
+                posedit = str(position) + ref + '>' + alt
+
+        # Assign reference sequence type if it is missing
+        if accession in ["NC_012920.1", "NC_001807.4"]:
+            var_type = "m"
+        else:
+            var_type = validator.db.ref_type_assign(accession)
+            var_type = var_type[1]
+    # this among other things will force gene type variants to at least specify c/n etc.
+    if not posedit:
+        error = 'Unable to identify a dot (.) in the variant description %s following the reference sequence ' \
+                'type (g,c,n,r, or p). A dot is required in HGVS variant ' \
+                'descriptions to separate the reference type from the variant position i.e. <accession>:<type>. ' \
+                'e.g. :g.' % variant.quibble
+        variant.warnings.append(error)
+        logger.warning(error)
+        skipvar = True
+    variant.quibble = accession + ':' + var_type + '.' + posedit
+    logger.debug("Completed VCF-HVGS step 2 for %s", variant.quibble)
     return skipvar
 
 
@@ -405,12 +392,16 @@ def gene_symbol_catch(variant, validator, select_transcripts_dict_plus_version):
     """
     skipvar = False
     query_a_symbol, _sep, tx_edit = variant.quibble.partition(':')
-    if not (query_a_symbol[:3] in ['NC','NM_','NR_','ENST'] or
-            query_a_symbol.startswith('ENST')
-            ) and re.search(r'\w+:[cn]\.', variant.quibble):
+    if not (query_a_symbol[:3] in ['NC_','NW_','NM_','NR_','NG_','LRG'] or
+            query_a_symbol[:4].startswith('ENST')
+            ) and tx_edit[:2] in ['c.','n.']:
         try:
             is_it_a_gene = validator.db.get_hgnc_symbol(query_a_symbol)
-            if is_it_a_gene != 'none':
+            if is_it_a_gene == 'none':
+                variant.warnings.append(chr_num + ' is not part of genome build ' + validator.selected_assembly)
+                logger.warning(chr_num + ' is not part of genome build ' + validator.selected_assembly)
+                skipvar = True
+            else:
                 uta_symbol = validator.db.get_uta_symbol(is_it_a_gene)
                 available_transcripts = validator.hdp.get_tx_for_gene(uta_symbol)
                 select_from_these_transcripts = []

--- a/VariantValidator/modules/vvDBGet.py
+++ b/VariantValidator/modules/vvDBGet.py
@@ -11,15 +11,15 @@ class Mixin(vvDBInit.Mixin):
     """
 
     @handleCursor
-    def execute(self, query):
+    def execute(self, *query_args):
         # Connect and create cursor
         conn = self.get_conn()
         cursor = self.get_cursor(conn)
 
-        cursor.execute(query)
+        cursor.execute(*query_args)
         row = cursor.fetchone()
         if row is None:
-            logger.debug("No data returned from query " + str(query))
+            logger.debug("No data returned from query " + str(query_args))
             row = ['none', 'No data']
 
         # Close conn
@@ -28,15 +28,15 @@ class Mixin(vvDBInit.Mixin):
         return row
 
     @handleCursor
-    def execute_all(self, query):
+    def execute_all(self, *query_args):
         # Connect and create cursor
         conn = self.get_conn()
         cursor = self.get_cursor(conn)
 
-        cursor.execute(query)
+        cursor.execute(*query_args)
         rows = cursor.fetchall()
         if not rows:
-            logger.debug("No data returned from query " + str(query))
+            logger.debug("No data returned from query " + str(query_args))
             rows = ['none', 'No data']
 
         # Close conn
@@ -46,42 +46,42 @@ class Mixin(vvDBInit.Mixin):
 
     # from dbfetchone
     def get_uta(self, gene_symbol):
-        query = "SELECT utaSymbol FROM transcript_info WHERE hgncSymbol = '%s'" % gene_symbol
-        return self.execute(query)
+        query = "SELECT utaSymbol FROM transcript_info WHERE hgncSymbol = %s"
+        return self.execute(query,(gene_symbol,))
 
     def get_hgnc(self, gene_symbol):
-        query = "SELECT hgncSymbol FROM transcript_info WHERE utaSymbol = '%s'" % gene_symbol
-        return self.execute(query)
+        query = "SELECT hgncSymbol FROM transcript_info WHERE utaSymbol = %s"
+        return self.execute(query,(gene_symbol,))
 
     def get_transcript_description(self, transcript_id):
-        query = "SELECT description FROM transcript_info WHERE refSeqID = '%s'" % transcript_id
-        return str(self.execute(query)[0])
+        query = "SELECT description FROM transcript_info WHERE refSeqID = %s"
+        return str(self.execute(query,(transcript_id,))[0])
 
     def get_transcript_annotation(self, transcript_id):
-        query = "SELECT transcriptVariant FROM transcript_info WHERE refSeqID = '%s'" % transcript_id
-        return str(self.execute(query)[0])
+        query = "SELECT transcriptVariant FROM transcript_info WHERE refSeqID = %s"
+        return str(self.execute(query,(transcript_id,))[0])
 
     def get_gene_symbol_from_transcript_id(self, transcript_id):
-        query = "SELECT hgncSymbol FROM transcript_info WHERE refSeqID = '%s'" % transcript_id
-        return str(self.execute(query)[0])
+        query = "SELECT hgncSymbol FROM transcript_info WHERE refSeqID = %s"
+        return str(self.execute(query,(transcript_id,))[0])
 
     def get_refseq_data_by_refseq_id(self, refseq_id, genome_build):
         query = "SELECT refSeqGeneID, refSeqChromosomeID, genomeBuild, startPos, endPos, orientation, totalLength, " \
-                "chrPos, rsgPos, entrezID, hgncSymbol FROM refSeqGene_loci WHERE refSeqGeneID = '%s' " \
-                "AND genomeBuild = '%s'" % (refseq_id, genome_build)
-        return self.execute(query)
+                "chrPos, rsgPos, entrezID, hgncSymbol FROM refSeqGene_loci WHERE refSeqGeneID = %s " \
+                "AND genomeBuild = %s"
+        return self.execute(query,(refseq_id, genome_build))
 
     def get_gene_symbol_from_refseq_id(self, refseq_id):
-        query = "SELECT hgncSymbol FROM refSeqGene_loci WHERE refSeqGeneID = '%s'" % refseq_id
-        return self.execute(query)[0]
+        query = "SELECT hgncSymbol FROM refSeqGene_loci WHERE refSeqGeneID = %s"
+        return self.execute(query,(refseq_id,))[0]
 
     def get_refseq_id_from_lrg_id(self, lrg_id):
-        query = "SELECT RefSeqGeneID FROM LRG_RSG_lookup WHERE lrgID = '%s'" % lrg_id
-        return self.execute(query)[0]
+        query = "SELECT RefSeqGeneID FROM LRG_RSG_lookup WHERE lrgID = %s"
+        return self.execute(query,(lrg_id,))[0]
 
     def get_refseq_transcript_id_from_lrg_transcript_id(self, lrg_tx_id):
-        query = "SELECT RefSeqTranscriptID FROM LRG_transcripts WHERE LRGtranscriptID = '%s'" % lrg_tx_id
-        return self.execute(query)[0]
+        query = "SELECT RefSeqTranscriptID FROM LRG_transcripts WHERE LRGtranscriptID = %s"
+        return self.execute(query,(lrg_tx_id,))[0]
 
     def get_lrg_transcript_id_from_refseq_transcript_id(self, rst_id):
         if not LRG_TX_LINK:
@@ -92,31 +92,31 @@ class Mixin(vvDBInit.Mixin):
         return LRG_TX_LINK.get(rst_id,'none')
 
     def get_lrg_id_from_refseq_gene_id(self, rsg_id):
-        query = "SELECT lrgID, status FROM LRG_RSG_lookup WHERE RefSeqGeneID = '%s'" % rsg_id
-        return self.execute(query)
+        query = "SELECT lrgID, status FROM LRG_RSG_lookup WHERE RefSeqGeneID = %s"
+        return self.execute(query,(rsg_id,))
 
     def get_refseqgene_info(self, refseqgene_id, primary_assembly):
         query = "SELECT refSeqGeneID, refSeqChromosomeID, genomeBuild, startPos, endPos FROM refSeqGene_loci " \
-                "WHERE refSeqGeneID = '%s' AND genomeBuild = '%s'" % (refseqgene_id, primary_assembly)
-        return self.execute(query)
+                "WHERE refSeqGeneID = %s AND genomeBuild = %s"
+        return self.execute(query,(refseqgene_id, primary_assembly))
 
     def get_refseq_protein_id_from_lrg_protein_id(self, lrg_p):
-        query = "SELECT RefSeqProteinID FROM LRG_proteins WHERE LRGproteinID = '%s'" % lrg_p
-        return self.execute(query)[0]
+        query = "SELECT RefSeqProteinID FROM LRG_proteins WHERE LRGproteinID = %s"
+        return self.execute(query,(lrg_p,))[0]
 
     def get_lrg_protein_id_from_ref_seq_protein_id(self, rs_p):
-        query = "SELECT LRGproteinID FROM LRG_proteins WHERE  RefSeqProteinID = '%s'" % rs_p
-        return self.execute(query)[0]
+        query = "SELECT LRGproteinID FROM LRG_proteins WHERE  RefSeqProteinID = %s"
+        return self.execute(query,(rs_p,))[0]
 
     def get_lrg_data_from_lrg_id(self, lrg_id):
-        query = "SELECT * FROM LRG_RSG_lookup WHERE lrgID = '%s'" % lrg_id
-        return self.execute(query)
+        query = "SELECT * FROM LRG_RSG_lookup WHERE lrgID = %s"
+        return self.execute(query,(lrg_id,))
 
     def get_transcript_info_for_gene(self, gene_symbol):
         query = "SELECT refSeqID, description, transcriptVariant, currentVersion, hgncSymbol, utaSymbol, " \
                 "updated, IF(updated < NOW() - INTERVAL 3 MONTH , 'true', 'false') FROM transcript_info " \
-                "WHERE hgncSymbol = '%s'" % gene_symbol
-        return self.execute_all(query)
+                "WHERE hgncSymbol = %s"
+        return self.execute_all(query,(gene_symbol,))
 
     def get_g_to_g_info(self, rsg_id=None, gen_id=None, start=None, end=None):
         """
@@ -127,32 +127,37 @@ class Mixin(vvDBInit.Mixin):
         query = "SELECT refSeqGeneID, refSeqChromosomeID, startPos, endPos, orientation, hgncSymbol, " \
                 "genomeBuild FROM refSeqGene_loci"
         if rsg_id:
-            query = query + f" WHERE refSeqGeneID='{rsg_id}' "
+            query = query + f" WHERE refSeqGeneID= %s "
+            query_vals = (rsg_id,)
         elif gen_id:
-            query = query + f" WHERE refSeqChromosomeID='{gen_id}' "
+            query = query + f" WHERE refSeqChromosomeID= %s "
+            query_vals = (gen_id,)
             if start:
-                query = query + f"AND startPos <= {str(start)} "
+                query = query + f"AND startPos <= %s "
+                query_vals = query_vals + (str(start),)
             if end:
-                query = query + f"AND endPos >= {str(end)} "
-        return self.execute_all(query)
+                query = query + f"AND endPos >= %s "
+                query_vals = query_vals + (str(end),)
+        return self.execute_all(query,query_vals)
 
     def get_all_transcript_id(self):
         query = "SELECT refSeqID FROM transcript_info"
         return self.execute_all(query)
 
     def get_stable_gene_id_info(self, hgnc_symbol):
-        query = "SELECT * FROM stableGeneIds WHERE hgnc_symbol = '%s'" % hgnc_symbol
-        return self.execute(query)
+        query = "SELECT * FROM stableGeneIds WHERE hgnc_symbol = %s"
+        return self.execute(query,(hgnc_symbol,))
 
     def get_stable_gene_id_from_hgnc_id(self, hgnc_id):
-        query = "SELECT * FROM stableGeneIds WHERE hgnc_id = '%s'" % hgnc_id
-        return self.execute(query)
+        query = "SELECT * FROM stableGeneIds WHERE hgnc_id = %s"
+        return self.execute(query,(hgnc_id,))
 
     def get_transcripts_from_annotations(self, statement):
-        query = "SELECT * FROM transcript_info WHERE transcriptVariant LIKE '%{}%'".format(statement)
+        testval = "%" + statement + "%"
+        query = "SELECT * FROM transcript_info WHERE transcriptVariant LIKE %s"
 
         # print("My query is: ", query)
-        return self.execute_all(query)
+        return self.execute_all(query,(testval,))
 
     def get_db_version(self):
         """

--- a/VariantValidator/modules/vvDatabase.py
+++ b/VariantValidator/modules/vvDatabase.py
@@ -33,8 +33,8 @@ class Database(vvDBInsert.Mixin):
         # Expiry set to 12 months because we will from 2021 be rolling out 3-monthly database dumps of the validator db
         query = "SELECT refSeqID, description, transcriptVariant, currentVersion, hgncSymbol, utaSymbol, updated, " \
                 "IF(updated < NOW() - INTERVAL 12 MONTH , 'true', 'false') FROM transcript_info WHERE " \
-                "refSeqID = '%s'" % entry
-        cursor.execute(query)
+                "refSeqID = %s"
+        cursor.execute(query,(entry,))
         row = cursor.fetchone()
         if row is None:
             row = ['none', 'No data']

--- a/VariantValidator/modules/vvMixinInit.py
+++ b/VariantValidator/modules/vvMixinInit.py
@@ -832,7 +832,7 @@ class Mixin:
                 elif len(pro_inv_info['prot_ins_seq']) == 0:
                     posedit = VVPosEdit(
                         pos = Interval(start = AAPosition(base = pro_inv_info['edit_start'], aa = from_aa)),
-                        edit = AARefAlt(alt = ''),
+                        edit = AARefAlt(ref = pro_inv_info['prot_del_seq']),
                         uncertain = True,
                         nucleotide_not_equal=nucleotide_not_equal)
                 else:

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -31194,6 +31194,19 @@ class TestVariantsAuto(TestCase):
         results = self.vv.validate(variant, 'GRCh38','all').format_as_dict(test=True)
         assert "mitochondrial_variant_1" in results.keys()
 
+    def test_issue_711(self):
+        #formats like 'chr17(GRCh38):g.50198002C>A' where not being handled correctly
+
+        # Test that it fails for genome mismatch
+        results = self.vv.validate('chr17(GRCh38):g.50198002C>A', 'GRCh37','all').format_as_dict(test=True)
+        assert 'validation_warning_1' in results
+        assert 'genome build' in results['validation_warning_1']['validation_warnings'][0]
+
+        # Test that we get a valid response when they match
+        results = self.vv.validate('chr17(GRCh38):g.50198002C>A', 'GRCh38','all').format_as_dict(test=True)
+        assert "NM_000088.4:c.589G>T" in results
+
+
 # <LICENSE>
 # Copyright (C) 2016-2025 VariantValidator Contributors
 #

--- a/tests/test_variantformatter_transcript_selection.py
+++ b/tests/test_variantformatter_transcript_selection.py
@@ -1,16 +1,19 @@
 from VariantFormatter import simpleVariantFormatter
 import VariantValidator
-vfo = VariantValidator.Validator()
 
 
 class TestVFvariantsTranscriptSelection(object):
     @classmethod
     def setup_class(cls):
-        vfo.testing = False
+        cls.vfo = VariantValidator.Validator()
+        cls.vfo.testing = False
 
     def test_transcript_selection_raw(self):
-        results = simpleVariantFormatter.format('NC_000005.10:g.140114829del',
-                                                                 'GRCh38', 'refseq', "raw", False, True, testing=False)
+        results = simpleVariantFormatter.format(
+                'NC_000005.10:g.140114829del',
+                'GRCh38', 'refseq', "raw",
+                False, True, testing=False,
+                validator=self.vfo)
         print(results)
         assert 'NC_000005.10:g.140114829del' in results.keys()
         assert 'NM_005859.3' in results['NC_000005.10:g.140114829del'][
@@ -21,8 +24,11 @@ class TestVFvariantsTranscriptSelection(object):
             'NC_000005.10:g.140114829del']['hgvs_t_and_p'].keys()
 
     def test_transcript_selection_all(self):
-        results = simpleVariantFormatter.format('NC_000005.10:g.140114829del',
-                                                                 'GRCh38', 'refseq', "all", False, True, testing=False)
+        results = simpleVariantFormatter.format(
+                'NC_000005.10:g.140114829del',
+                'GRCh38', 'refseq', "all",
+                False, True, testing=False,
+                validator=self.vfo)
         print(results)
         assert 'NC_000005.10:g.140114829del' in results.keys()
         assert 'NM_005859.3' not in results['NC_000005.10:g.140114829del'][
@@ -33,8 +39,11 @@ class TestVFvariantsTranscriptSelection(object):
             'NC_000005.10:g.140114829del']['hgvs_t_and_p'].keys()
 
     def test_transcript_selection_mane_select(self):
-        results = simpleVariantFormatter.format('NC_000005.10:g.140114829del',
-                                                                 'GRCh38', 'refseq', "mane_select", False, True, testing=False)
+        results = simpleVariantFormatter.format(
+                'NC_000005.10:g.140114829del',
+                'GRCh38', 'refseq', "mane_select",
+                False, True, testing=False,
+                validator=self.vfo)
         print(results)
         assert 'NC_000005.10:g.140114829del' in results.keys()
         assert 'NM_005859.3' not in results['NC_000005.10:g.140114829del'][
@@ -45,8 +54,11 @@ class TestVFvariantsTranscriptSelection(object):
             'NC_000005.10:g.140114829del']['hgvs_t_and_p'].keys()
 
     def test_transcript_selection_select(self):
-        results = simpleVariantFormatter.format('NC_000005.10:g.140114829del',
-                                                                 'GRCh38', 'refseq', "select", False, True, testing=False)
+        results = simpleVariantFormatter.format(
+                'NC_000005.10:g.140114829del',
+                'GRCh38', 'refseq', "select",
+                False, True, testing=False,
+                validator=self.vfo)
         print(results)
         assert 'NC_000005.10:g.140114829del' in results.keys()
         assert 'NM_005859.3' not in results['NC_000005.10:g.140114829del'][
@@ -57,8 +69,11 @@ class TestVFvariantsTranscriptSelection(object):
             'NC_000005.10:g.140114829del']['hgvs_t_and_p'].keys()
 
     def test_transcript_selection_nm(self):
-        results = simpleVariantFormatter.format('NC_000005.10:g.140114829del',
-                                                                 'GRCh38', 'refseq', "NM_005859.4", False, True, testing=False)
+        results = simpleVariantFormatter.format(
+                'NC_000005.10:g.140114829del',
+                'GRCh38', 'refseq', "NM_005859.4",
+                False, True, testing=False,
+                validator=self.vfo)
         print(results)
         assert 'NC_000005.10:g.140114829del' in results.keys()
         assert 'NM_005859.3' not in results['NC_000005.10:g.140114829del'][
@@ -69,8 +84,11 @@ class TestVFvariantsTranscriptSelection(object):
             'NC_000005.10:g.140114829del']['hgvs_t_and_p'].keys()
 
     def test_transcript_selection_mane(self):
-        results = simpleVariantFormatter.format('NC_000007.14:g.140924703T>C',
-                                                                 'GRCh38', 'refseq', "mane", False, True, testing=False)
+        results = simpleVariantFormatter.format(
+                'NC_000007.14:g.140924703T>C',
+                'GRCh38', 'refseq', "mane",
+                False, True, testing=False,
+                validator=self.vfo)
         print(results)
         assert 'NC_000007.14:g.140924703T>C' in results.keys()
         assert 'NM_004333.6' in results['NC_000007.14:g.140924703T>C'][


### PR DESCRIPTION
Fixes for https://github.com/openvar/variantValidator/issues/711 , https://github.com/openvar/variantValidator/issues/710 , and https://github.com/openvar/variantValidator/issues/722 (+ related possible crashes, at least to the point of not crashing and producing the normal gene/id not found warning for users)

Plus some improvement on  https://github.com/openvar/variantValidator/issues/676 , although not as much as was originally hoped for.

Some extra work on preventing re-occurrence of issues related to https://github.com/openvar/variantValidator/issues/710 is still ongoing, we probably want to either get more complex stop changes working, and tested, or remove the currently unreachable code before adding the extra tests, but adding these tests can probably be left until after the next release.

This set, particularly the work on Variant Formatter depends on https://github.com/openvar/variantFormatter/pull/91 being trigged and then re-pulled into master (or the alt version of this directly against the main branch), **one of which should be completed first**.