### PR TITLE
De-indent and tidy a bit

### DIFF
--- a/tests/test_gene2transcript.py
+++ b/tests/test_gene2transcript.py
@@ -233,6 +233,23 @@ class TestGene2Transcripts(unittest.TestCase):
         assert output4["lovd_messages"] is not None
         assert "error" not in output4.keys()
 
+    def test_orf_genes(self):
+        output = self.vv.gene2transcripts('C3orf52')
+        print(output)
+        assert 'current_symbol' in output
+        assert output['current_symbol'] == 'C3orf52'
+        assert 'hgnc' in output
+        assert output['hgnc'] == 'HGNC:26255'
+        assert 'transcripts' in output
+        output = self.vv.gene2transcripts('C3ORF52')
+        print(output)
+        assert 'current_symbol' in output
+        assert output['current_symbol'] == 'C3orf52'
+        assert 'hgnc' in output
+        assert output['hgnc'] == 'HGNC:26255'
+        assert 'transcripts' in output
+
+
 
 # <LICENSE>
 # Copyright (C) 2016-2025 VariantValidator Contributors


### PR DESCRIPTION
A little tweak to reduce indenting, as well as reducing the use of 'try' to handle what should be a normal (and so fairly common) empty result, and removing a redundant use of LOVD, the LOVD endpoint will be called again on the same input if it fails to match a gene ID or transcript later, and won't be needed, or used, if it succeeds.