### PR TITLE
Update VV to work with added vv_hgvs relative accs

### DIFF
--- a/VariantValidator/modules/format_converters.py
+++ b/VariantValidator/modules/format_converters.py
@@ -826,6 +826,7 @@ def intronic_converter(variant, validator, skip_check=False, uncertain=False):
                 variant.quibble = f"{transcript}:{remainder}"
             else:
                 variant.quibble.ac = transcript
+                variant.quibble.rel_ac = genomic
             return variant
         else:
             genomic_ref = acc_section.split('(')[0]
@@ -837,6 +838,7 @@ def intronic_converter(variant, validator, skip_check=False, uncertain=False):
 
         if parsed:
             variant.quibble.ac = transy
+            variant.quibble.rel_ac = genomic_ref
             hgvs_transy = variant.quibble
         else:
             variant.quibble = variant.quibble.replace(acc_section,transy)

--- a/VariantValidator/modules/vvMixinConverters.py
+++ b/VariantValidator/modules/vvMixinConverters.py
@@ -90,9 +90,10 @@ class Mixin(vvMixinInit.Mixin):
             var_g = self.hp.parse_hgvs_variant(variant)
             return var_g
 
-    def myevm_t_to_g(self, hgvs_c, no_norm_evm, primary_assembly, hn):
+    def myevm_t_to_g(self, hgvs_c, no_norm_evm, primary_assembly, hn, reset_g_origin=False):
         """
         Enhanced transcript to genome position mapping function using evm
+        If reset_g_origin is false keeps the original mapping source, otherwise re-sets
         Deals with mapping from transcript positions that do not exist in the genomic sequence
         i.e. the stated position aligns to a genomic gap!
         Trys to ensure that a genomic position is always returned even if the c. or n. transcript
@@ -245,10 +246,13 @@ class Mixin(vvMixinInit.Mixin):
         hgvs_genomic = None
 
         try:
+            if reset_g_origin:
+                hgvs_c.rel_ac = ''
             hgvs_genomic = no_norm_evm.t_to_g(hgvs_c)
             hn.normalize(hgvs_genomic)  # Check the validity of the mapping
 
-            # This will fail on multiple refs for NC_
+            # This will fail on multiple refs for NC_ if the origin is not already set!
+            # if the origin is set then this keeps the relative genomic origin, which can include NG_ or alts!
         except vvhgvs.exceptions.HGVSError:
             # Recover all available mapping options from UTA
 


### PR DESCRIPTION
Adding relative accessions to vv_hgvs for transcript variants, for use when mapped from the genome, or provided deliberately (eg for intronic variation states), was needed to avoid failures due to differing ideas of exon locations for differing genomic mappings of the same transcript.

This however has some consequences to the behaviour of the vv_hgvs 'evm' or 'easy variant mapper' that need relevant changes to VV to account for.  This also allowed better handling of user input with specified genomic accessions for intronic locations. This change is needed for VV to fully work with the changes, but also requires the vv_hgvs updates or else it will case crashes.

Warnings for the reduced alternative transcript discovery when alt genomic refs are specified for intronic :c. type variation inputs, which should be expected by users, but might not in practice, are not so urgent and so are added in this change. (we might want to add these later?)