### PR TITLE
Adjust warning for genomic data only variants

### DIFF
--- a/VariantValidator/modules/mappers.py
+++ b/VariantValidator/modules/mappers.py
@@ -106,6 +106,12 @@ def gene_to_transcripts(variant, validator, select_transcripts_dict):
     """
     If mapping to transcripts has been unsuccessful, provide relevant details
     """
+    # Keep error messages consistent with later by pre-storing
+    no_tx_found_error = (
+        "No individual transcripts have been identified that fully overlap the "
+        "described variation in the genomic sequence. Large variants might span"
+        " one or more genes and are currently only described at the genome (g.)"
+        " level.")
     if len(rel_var) == 0:
 
         # Check for NG_
@@ -117,12 +123,10 @@ def gene_to_transcripts(variant, validator, select_transcripts_dict):
             try:
                 refseqgene_data = refseqgene_data[0]
             except IndexError:
-                error = ('No transcripts found that fully overlap the described variation in the genomic '
-                         'sequence')
                 # set output type flag
                 variant.output_type_flag = 'intergenic'
                 # set genomic and where available RefSeqGene outputs
-                variant.warnings.append(error)
+                variant.warnings.append(no_tx_found_error)
                 error = 'Mapping unavailable for RefSeqGene ' + str(variant.hgvs_formatted) + \
                         ' using alignment method = ' + validator.alt_aln_method
                 variant.warnings.append(error)
@@ -177,8 +181,7 @@ def gene_to_transcripts(variant, validator, select_transcripts_dict):
                                  f'fully overlap the described variation in '
                                  f'the genomic sequence. Try selecting one of the default options')
                     else:
-                        error = ('No transcripts found that fully overlap the described variation in the genomic '
-                                 'sequence')
+                        error = no_tx_found_error
                     # set output type flag
                     variant.output_type_flag = 'intergenic'
                     # set genomic and where available RefSeqGene outputs

--- a/tests/test_expanded_repeats.py
+++ b/tests/test_expanded_repeats.py
@@ -959,7 +959,7 @@ class TestExpandedRepeatRefSeqGenomic(TestCase):
             " the core HGVS descriptions provided",
             'NG_012232.1:g.6_7insTTTTTTTTTTTTTTTT automapped to genome position '
             'NC_000023.10:g.33362724_33362725insAAAAAAAAAAAAAAAA',
-            'No transcripts found that fully overlap the described variation in the genomic sequence'
+            'No individual transcripts have been identified that fully overlap the described variation in the genomic sequence. Large variants might span one or more genes and are currently only described at the genome (g.) level.'
         ]
 
     def test_RSG_genomic_single_position_to_span(self):
@@ -975,7 +975,7 @@ class TestExpandedRepeatRefSeqGenomic(TestCase):
             "ExpandedRepeatError: The coordinates for the repeat region are stated incorrectly in the submitted description NG_012232.1:g.4T[20]. The corrected description is NG_012232.1:g.3_6T[20]",
             "ExpandedRepeatWarning: NG_012232.1:g.3_6T[20] should only be used as an annotation for the core HGVS descriptions provided",
             "NG_012232.1:g.6_7insTTTTTTTTTTTTTTTT automapped to genome position NC_000023.10:g.33362724_33362725insAAAAAAAAAAAAAAAA",
-            "No transcripts found that fully overlap the described variation in the genomic sequence"
+            'No individual transcripts have been identified that fully overlap the described variation in the genomic sequence. Large variants might span one or more genes and are currently only described at the genome (g.) level.'
         ]
 
     def test_incorrect_RSG_genomic_range(self):
@@ -1159,7 +1159,7 @@ class TestExpandedRepeaLocusReferenceGenomic(TestCase):
             "ExpandedRepeatError: The coordinates for the repeat region are stated incorrectly in the submitted description LRG_199:g.4T[20]. The corrected description is NG_012232.1:g.3_6T[20]",
             "ExpandedRepeatWarning: NG_012232.1:g.3_6T[20] should only be used as an annotation for the core HGVS descriptions provided",
             "NG_012232.1:g.6_7insTTTTTTTTTTTTTTTT automapped to genome position NC_000023.10:g.33362724_33362725insAAAAAAAAAAAAAAAA",
-            "No transcripts found that fully overlap the described variation in the genomic sequence"
+            "No individual transcripts have been identified that fully overlap the described variation in the genomic sequence. Large variants might span one or more genes and are currently only described at the genome (g.) level."
         ]
 
     def test_incorrect_LRG_genomic_range(self):

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -31215,7 +31215,7 @@ class TestVariantsAuto(TestCase):
             "refseqgene": "https://www.ncbi.nlm.nih.gov/nuccore/NG_029236.1" }
 
         assert results["intergenic_variant_1"]["validation_warnings"] == [
-            "No transcripts found that fully overlap the described variation in the genomic sequence",
+            "No individual transcripts have been identified that fully overlap the described variation in the genomic sequence. Large variants might span one or more genes and are currently only described at the genome (g.) level.",
             "Mapping unavailable for RefSeqGene NG_029236.1:g.501delG using alignment method = splign"
         ]
 


### PR DESCRIPTION
The original warning is only clear if you understand the limitations of the current hgvs standard, but many of our users do not! This is more wordy, but much more clear.

See https://github.com/openvar/variantValidator/issues/751 for more details