### PR TITLE
Expanded repeat in out, moved + hgvs object input

### DIFF
--- a/VariantValidator/modules/expanded_repeats.py
+++ b/VariantValidator/modules/expanded_repeats.py
@@ -87,6 +87,8 @@ class TandemRepeats:
         self.no_norm_evm = False
         self.genomic_conversion = None
         self.original_position = None
+        self.reference_sequence_bases = None
+
         # Define the wobble bases map with proper regex
         self._wobble_bases_map = {
             'A': r'A',       # Adenine
@@ -267,10 +269,11 @@ class TandemRepeats:
         logger.info(
             f"Checking range given: "\
             f"check_positions_given({self.repeat_sequence}, "\
-            f"{self.variant_position},{self.copy_number})"
+            f"{self.variant_position}, {self.copy_number})"
         )
         start,end = self.variant_position.split("_")
         reference_repeat_sequence = validator.sf.fetch_seq(self.reference, int(start)-1, int(end))
+        logger.info(f"Reference repeat sequence: {reference_repeat_sequence}")
 
         # Check if the length of reference_repeat_sequence is a multiple of the length of query_str
         if len(reference_repeat_sequence) % len(self.repeat_sequence) != 0:
@@ -287,6 +290,8 @@ class TandemRepeats:
         match = regex.search(reference_repeat_sequence)
         try:
             match.group()
+            logger.info(f"Regex matched {match.group()}")
+            self.reference_sequence_bases = match.group()
             return
         except AttributeError:
             if repeated_str == "":
@@ -484,6 +489,7 @@ class TandemRepeats:
         if self.intronic_g_reference:
             ref = self.intronic_g_reference
         requested_sequence = validator.sf.fetch_seq(ref, start, end)
+        logger.info(f"Requested sequence: {requested_sequence} from {ref} at {start}-{end}")
 
         # Critical, do not use cached regex
         regex = self.build_regex(self.repeat_sequence)
@@ -765,20 +771,26 @@ def convert_tandem(variant, validator, build, my_all):
         return False
     else:
         expanded_variant_string = expanded_variant.reformat(validator)
+
+
         try:
             variant.expanded_repeat = {"variant": expanded_variant_string,
                                        "position": expanded_variant.variant_position,
                                        "copy_number": expanded_variant.copy_number,
                                        "repeat_sequence": expanded_variant.repeat_sequence,
                                        "reference": expanded_variant.reference,
-                                       "prefix": expanded_variant.prefix}
+                                       "prefix": expanded_variant.prefix,
+                                       "reference_sequence_bases": expanded_variant.reference_sequence_bases}
+            logger.info(f"variant.expanded_repeat: {variant.expanded_repeat}")
         except AttributeError:
             expanded_repeat = {"variant": expanded_variant_string,
                                "position": expanded_variant.variant_position,
                                "copy_number": expanded_variant.copy_number,
                                "repeat_sequence": expanded_variant.repeat_sequence,
                                "reference": expanded_variant.reference,
-                               "prefix": expanded_variant.prefix}
+                               "prefix": expanded_variant.prefix,
+                               "reference_sequence_bases": expanded_variant.reference_sequence_bases}
+            logger.info(f"expanded_repeat: {expanded_repeat}")
             return expanded_repeat
 
         return True

--- a/VariantValidator/modules/expanded_repeats.py
+++ b/VariantValidator/modules/expanded_repeats.py
@@ -14,14 +14,21 @@ import re
 import logging
 import copy
 from vvhgvs.assemblymapper import AssemblyMapper
-from .hgvs_utils import hgvs_obj_from_existing_edit, hgvs_delins_parts_to_hgvs_obj
+# AlignmentMapper allows us to skip redundant validation & ref filling on c<->n
+# the no normalisation flags for AssemblyMapper only skip the validation & post
+# map replacement but ref will always be subject to initial pre map filling
+import vvhgvs
+from vvhgvs.alignmentmapper import AlignmentMapper
+from vvhgvs.location import BaseOffsetInterval, Interval
+
+from .hgvs_utils import hgvs_delins_parts_to_hgvs_obj, \
+        _hgvs_offset_pos_from_str_in
 # Set up logger
 logger = logging.getLogger(__name__)
 
 
 class RepeatSyntaxError(Exception):
     """Raised when the syntax of the expanded repeat is incorrect"""
-    pass
 
 # Established class for Tandem repeats
 class TandemRepeats:
@@ -80,8 +87,7 @@ class TandemRepeats:
         self.build = build
         self.select_transcripts = select_transcripts
         self.variant_str = variant_str
-        self.cds_start = None # only valid for C type tx
-        self.cds_end = None # only valid for C type tx
+        self._c_to_n_tx_maper = None # only valid for c<->n type mappings
         self.g_strand = 1 # only valid for intronic +/-1
         self.evm = False
         self.no_norm_evm = False
@@ -180,11 +186,33 @@ class TandemRepeats:
                 if char.isalpha():
                     if char not in "AaCcTtGgUuMmNnRrYyKkSsWwHhBbVvDd":
                         raise RepeatSyntaxError(
-                            "RepeatSyntaxError: Please ensure the repeated sequence"
-                            " includes only Aa, Cc, Tt, Gg, Uu or a valid IUPAC nucleotide code from "
+                            "RepeatSyntaxError: Please ensure the repeated sequence includes"
+                            " only Aa, Cc, Tt, Gg, Uu or a valid IUPAC nucleotide code from "
                             "https://genome.ucsc.edu/goldenPath/help/iupac.html")
             repeat_sequence = rep_seq.group()
             variant_position = pos_and_seq[:rep_seq.start()]
+            if prefix == 'g':
+                if '_' in variant_position:
+                    start, _sep, end = variant_position.partition('_')
+                    start = int(start)
+                    end = int(end)
+                else:
+                    start = int(variant_position)
+                    end = start
+                variant_position =  Interval(
+                    start=vvhgvs.location.SimplePosition(base=start),
+                    end=vvhgvs.location.SimplePosition(base=end))
+            else:
+                if '_' in variant_position:
+                    start, _sep, end = variant_position.partition('_')
+                    variant_position = _hgvs_offset_pos_from_str_in(
+                            start,None,end=end,ref_type=prefix)
+                elif variant_position:
+                    variant_position = _hgvs_offset_pos_from_str_in(
+                            variant_position,1,ref_type=prefix)
+                variant_position = BaseOffsetInterval(
+                        start=variant_position[0],
+                        end=variant_position[1])
 
             # Get number of unit repeats
             copy_number, _sep, after_the_bracket = post_bracket.partition("]")
@@ -225,7 +253,7 @@ class TandemRepeats:
             assert (
                 "." in self.reference
             ), """Please ensure the transcript or gene version is included
-                  following a '.' after the transcript 
+                  following a '.' after the transcript
                   or gene name e.g. ENST00000357033.8"""
         return self.reference
 
@@ -241,12 +269,12 @@ class TandemRepeats:
         if self.reference.startswith("ENST"):
             assert (
                 self.prefix == "c"
-            ), """Please ensure variant type is coding 
-                if an Ensembl transcript is provided"""
+            ), """Please ensure variant type is coding
+            if an Ensembl transcript is provided"""
         elif self.reference.startswith("NM"):
             assert (
                 self.prefix == "c"
-            ), """Please ensure variant type is coding 
+            ), """Please ensure variant type is coding
                   if a RefSeq transcript is provided"""
         elif self.reference.startswith("NC"):
             assert (
@@ -269,17 +297,22 @@ class TandemRepeats:
         logger.info(
             f"Checking range given: "\
             f"check_positions_given({self.repeat_sequence}, "\
-            f"{self.variant_position}, {self.copy_number})"
+            f"{str(self.variant_position)}, {self.copy_number})"
         )
-        start,end = self.variant_position.split("_")
-        reference_repeat_sequence = validator.sf.fetch_seq(self.reference, int(start)-1, int(end))
+        ref = self.reference
+        if self.intronic_g_reference:
+            ref = self.intronic_g_reference
+        reference_repeat_sequence = validator.sf.fetch_seq(
+                ref,
+                self.variant_position.start.base-1,
+                self.variant_position.end.base)
         logger.info(f"Reference repeat sequence: {reference_repeat_sequence}")
 
         # Check if the length of reference_repeat_sequence is a multiple of the length of query_str
         if len(reference_repeat_sequence) % len(self.repeat_sequence) != 0:
             raise RepeatSyntaxError(
-                f"RepeatSyntaxError: The stated range {self.variant_position} is not a multiple of "
-                f"the length of the provided repeat sequence {self.repeat_sequence}")
+                f"RepeatSyntaxError: The stated range {str(self.variant_position)} is not a "
+                f"multiple of the length of the provided repeat sequence {self.repeat_sequence}")
 
         # Create a new string by repeating query_str enough times
         repeated_str = self.repeat_sequence * (len(reference_repeat_sequence)
@@ -294,12 +327,65 @@ class TandemRepeats:
             self.reference_sequence_bases = match.group()
             return
         except AttributeError:
-            if repeated_str == "":
-                return
+            # We previously had a case for an empty repeated_str here, but that should always make
+            # a match.group() on a valid input and regex.search() should fail otherwise
             raise RepeatSyntaxError(
                 f"RepeatSyntaxError: The repeat sequence does not match the reference sequence at "
-                f"the given position {self.variant_position}, expected {repeated_str} but the "
+                f"the given position {str(self.variant_position)}, expected {repeated_str} but the "
                 f"reference is {reference_repeat_sequence} at the specified position")
+
+    def get_valid_n_or_g_range_from_input_pos(self, validator):
+        """
+        Substitute for get_range_from_single_or_start_pos without full re-build.
+
+        Works by converting c->n or c/n->g without rebuilding, leaves other
+        input untouched. Used to keep the original input range, mainly for
+        testing. Mutually exclusive with get_range_from_single_or_start_pos,
+        using both will break c type inputs. This also avoids ALL checks for
+        c/n intronic to g mapping, for the same reasons (testing or deliberate
+        maintenance of the original) so should be combined with extra tests for
+        the sequence state if it is being used for user visible output.
+        """
+        pos = self.variant_position
+        if isinstance(self.variant_position, BaseOffsetInterval) and (
+                pos.start.offset or pos.end.offset):
+            if not self.no_norm_evm:
+                # if we normalise at the wrong points we get the wrong ref seq back
+                # This mapper does call functions to "fill" and "replace" ref but
+                # the first runs without effect on intronic inputs, and the output
+                # genomic ref is used, so leave in the more complex form for now
+                self.no_norm_evm = AssemblyMapper(
+                        validator.hdp,
+                        assembly_name=self.build,
+                        alt_aln_method=validator.alt_aln_method,
+                        normalize=False,
+                        replace_reference=True
+                        )
+            var_n = hgvs_delins_parts_to_hgvs_obj(
+                    self.reference,
+                    self.prefix,
+                    self.variant_position,
+                    '',
+                    f"{self.repeat_sequence * int(self.copy_number)}")
+            self.original_position = copy.deepcopy(self.variant_position)
+            intronic_genomic_variant = self.no_norm_evm.t_to_g(var_n)
+            self.genomic_conversion = intronic_genomic_variant
+            self.intronic_g_reference = intronic_genomic_variant.ac
+            pos = intronic_genomic_variant.posedit.pos
+            # untested ref!
+            self.reference_sequence_bases = self.repeat_sequence * int(
+                (pos.end - pos.start + 1) / len(self.repeat_sequence))
+        elif self.prefix == "c":
+            # don't do c->n mapping on t_to_g targets
+            # if tx is coding and var is not c we get an error
+            self._get_c_tx_info(validator)
+            pos = self.convert_c_to_n_coordinates()
+            # untested ref!
+            self.reference_sequence_bases = self.repeat_sequence * int(
+                (pos.end - pos.start + 1) / len(self.repeat_sequence))
+
+        self.variant_position = pos
+
 
     def get_range_from_single_or_start_pos(self, validator):
         """
@@ -307,7 +393,7 @@ class TandemRepeats:
         Used both when a single start position is supplied
         and to rebuild ranges for validation purposes.
 
-        Currently this is also the only place that c->n mapping happens
+        Currently this is the only place that intronic g locations are derived
 
         Uses: self.variant_position
               validator (a VariantValidator object for data fetch, intronic
@@ -319,40 +405,39 @@ class TandemRepeats:
         Returns: The n based coordinate span of the repeat region, as found
 
         """
-        start_pos, _sep, end_pos = self.variant_position.partition('_')
-        if ('-' in start_pos[1:] or end_pos and '-' in end_pos[1:]) or (
-            '+' in start_pos or '+' in end_pos):
+        # due to the nature of hgvs object pos we always have end but it may == start
+        start_pos = self.variant_position.start
+        end_pos = self.variant_position.end
+        if isinstance(self.variant_position, BaseOffsetInterval) and (
+                start_pos.offset or end_pos.offset):
             logger.info(
                 "Re-fetching the range using adaptions for exon handling " +
-                f"using the range {self.variant_position} with a" +
+                f"using the range {str(self.variant_position)} with a " +
                 f"copy number of {self.copy_number} and repeat of "+
                 self.repeat_sequence
             )
         elif end_pos:
             logger.info(
                 "Re-fetching the range from the start position of a given " +
-                f"range using {start_pos} from {self.variant_position} with a" +
-                f"copy number of {self.copy_number} and repeat of "+
+                f"range using {start_pos} from {str(self.variant_position)} with a" +
+                f" copy number of {self.copy_number} and repeat of "+
                 self.repeat_sequence
             )
-            self.variant_position = start_pos
-        else:
-            logger.info(
-                f"Fetching the range from the start position of {start_pos} " +
-                f" with a copy number of {self.copy_number} and repeat of " +
-                self.repeat_sequence\
-            )
+            self.variant_position.end = copy.copy(end_pos)
 
         # Get the full reference sequence range of the variant
         # the within_ref_pos here is the start position in 0 based coordinates
 
-        try:
+        self.original_position = copy.deepcopy(self.variant_position)
+        if not (isinstance(self.variant_position, BaseOffsetInterval) and (
+                start_pos.offset or end_pos.offset)):
             if not self.prefix == "c":
-                within_ref_pos = int(self.variant_position) - 1
+                within_ref_pos = self.variant_position.start.base - 1
             else:
                 self._get_c_tx_info(validator)
-                within_ref_pos = int(self.convert_c_to_n_coordinates()) - 1
-        except ValueError:
+                pos = self.convert_c_to_n_coordinates()
+                within_ref_pos = pos.start.base - 1
+        else:
             if not self.no_norm_evm:
                 # if we normalise at the wrong points we get the wrong ref seq back
                 self.no_norm_evm = AssemblyMapper(
@@ -362,108 +447,98 @@ class TandemRepeats:
                         normalize=False,
                         replace_reference=True
                         )
-            if re.search(r"[0-9]+[+-][0-9]+", self.variant_position):
-                # Handle a range variant input, given current function's purpose we
-                # just dump range and re-build from the first base
+            # Handle a range variant input, given current function's purpose we
+            # just dump range and re-build from the first base
 
-                if "_" in self.variant_position:
-                    start_pos, _sep, end_pos = self.variant_position.partition('_')
-                    seq_check = hgvs_delins_parts_to_hgvs_obj(
-                            self.reference,
-                            self.prefix,
-                            start_pos,
-                            f"{self.repeat_sequence * int(self.copy_number)}",
-                            f"{self.repeat_sequence * int(self.copy_number)}",
-                            end=end_pos)
+            if self.variant_position.start != self.variant_position.end:
+                seq_check = hgvs_delins_parts_to_hgvs_obj(
+                        self.reference,
+                        self.prefix,
+                        self.variant_position,
+                        "",
+                        f"{self.repeat_sequence * int(self.copy_number)}")
 
-                    self.original_position = copy.copy(self.variant_position)
-                    intronic_genomic_variant = self.no_norm_evm.t_to_g(seq_check)
-                    self.genomic_conversion = intronic_genomic_variant
-
-                    # Check the exon boundaries
-                    self.check_exon_boundaries(validator)
-                    seq_check = self.evm.g_to_t(intronic_genomic_variant, self.reference)
-                    regex = self.build_regex(self.repeat_sequence)
-
-                    # Check for occurrences of the repeat sequence using regex
-                    matches = list(regex.finditer(seq_check.posedit.edit.ref))
-                    repeat_count = len(matches)
-                    if matches[0].start() != 0:
-                        # Create a new string by repeating query_str enough times
-                        repeated_str = self.repeat_sequence * (len(seq_check.posedit.edit.ref)
-                                                               // len(self.repeat_sequence))
-
-                        raise RepeatSyntaxError(
-                            f"RepeatSyntaxError: The repeat sequence does not match the reference sequence at "
-                            f"the given position {self.variant_position}, expected {repeated_str} but the "
-                            f"reference is {seq_check.posedit.edit.ref} at the specified position")
-                    elif repeat_count != int(self.copy_number):
-                        raise RepeatSyntaxError(
-                            f"RepeatSyntaxError: The repeat sequence does not match the expected copy number "
-                            f"at position {self.variant_position}. Expected {int(self.copy_number)} occurrences "
-                            f"of '{self.repeat_sequence}', but found {repeat_count} in reference sequence "
-                            f"'{seq_check.posedit.edit.ref}'.")
-
-                    start, _sep, end =  self.variant_position.partition('_')
-                    self.g_strand = validator.hdp.get_tx_exons(self.reference, intronic_genomic_variant.ac,
-                                                               validator.alt_aln_method)[0][3]
-                    self.original_position = copy.copy(self.variant_position)
-                    if  self.g_strand == -1:
-                        self.variant_position = end
-                    else:
-                        self.variant_position = start
-                else:
-                    # Create a variant for mapping to the genome containing the whole repeat, we used
-                    # to use only the first base of the repeat but this breaks on -1 mapping transcripts
-                    # with multi-base repeats
-                    length = len(self.repeat_sequence)
-                    pos = self.variant_position
-                    end = None
-                    if length == 1:
-                        pos = self.variant_position
-                    elif '+' in self.variant_position:
-                        tx_pos,_sep,intron_offset = self.variant_position.partition('+')
-                        intron_offset = int(intron_offset)
-                        pos = f"{tx_pos}+{intron_offset}"
-                        end = f"{tx_pos}+{str(intron_offset+length-1)}"
-                    elif '-' in self.variant_position:
-                        tx_pos,_sep,intron_offset = self.variant_position.partition('-')
-                        intron_offset = int(intron_offset)
-                        pos  = f"{tx_pos}-{intron_offset}"
-                        end = f"{tx_pos}-{str(intron_offset-length+1)}"
-                    intronic_variant = hgvs_delins_parts_to_hgvs_obj(
-                            self.reference,
-                            self.prefix,
-                            pos,
-                            self.repeat_sequence,
-                            self.repeat_sequence,
-                            end=end
-                            )
-                    intronic_genomic_variant = self.no_norm_evm.t_to_g(intronic_variant)
-                    self.g_strand = validator.hdp.get_tx_exons(intronic_variant.ac, intronic_genomic_variant.ac,
-                                                               validator.alt_aln_method)[0][3]
-                    self.original_position = copy.copy(self.variant_position)
-                    self.variant_position = intronic_genomic_variant.posedit.pos.start.base
-
-                self.intronic_g_reference = intronic_genomic_variant.ac
+                self.original_position = copy.deepcopy(self.variant_position)
+                intronic_genomic_variant = self.no_norm_evm.t_to_g(seq_check)
                 self.genomic_conversion = intronic_genomic_variant
-
-                # Check exon boundaries
+                # get ref length for complex cases (needed for checking)
+                ref_len = len(intronic_genomic_variant.posedit.edit.ref)
+                ref_copies = int(ref_len/len(self.repeat_sequence))
+                # Check the exon boundaries by using normalising mapper
                 self.check_exon_boundaries(validator)
-                within_ref_pos = intronic_genomic_variant.posedit.pos.start.base - 1
-                if self.g_strand == -1:
-                    self.reverse_complement(self.repeat_sequence)
+                seq_check = self.evm.g_to_t(intronic_genomic_variant, self.reference)
+                regex = self.build_regex(self.repeat_sequence)
+
+                # Check for occurrences of the repeat sequence using regex
+                matches = list(regex.finditer(seq_check.posedit.edit.ref))
+                repeat_count = len(matches)
+                if matches[0].start() != 0:
+                    # Create a new string by repeating query_str enough times
+                    repeated_str = self.repeat_sequence * (len(seq_check.posedit.edit.ref)
+                                                           // len(self.repeat_sequence))
+
+                    raise RepeatSyntaxError(
+                        "RepeatSyntaxError: The repeat sequence does not match the reference "
+                        f"sequence at the given position {str(self.variant_position)}, expected"
+                        f" {repeated_str} but the reference is {seq_check.posedit.edit.ref} at "
+                        "the specified position")
+                if repeat_count != ref_copies:
+                    raise RepeatSyntaxError(
+                        "RepeatSyntaxError: The repeat sequence does not match the expected "
+                        f"copy number at position {str(self.variant_position)}. Expected "
+                        f"{int(ref_copies)} occurrences of '{self.repeat_sequence}', but"
+                        f" found {repeat_count} in reference sequence "
+                        f"'{seq_check.posedit.edit.ref}'.")
+
+                self.g_strand = validator.hdp.get_tx_exons(
+                        self.reference, intronic_genomic_variant.ac,
+                        validator.alt_aln_method)[0][3]
+                # this is re-expanded later from the first base, to handle truncated input
+                if  self.g_strand == -1:
+                    self.variant_position.start = copy.copy(self.variant_position.end)
+                else:
+                    self.variant_position.end = copy.copy(self.variant_position.start)
             else:
-                raise RepeatSyntaxError(
-                    f"RepeatSyntaxError: The provided start coordinate {self.variant_position}"
-                    "does not appear to be a simple transcript coordinate, or an intronic "
-                    "location ")
+                # Create a variant for mapping to the genome containing the whole repeat, we
+                # used to use only the first base of the repeat but this breaks on -1 mapping
+                # transcripts with multi-base repeats
+                length = len(self.repeat_sequence)
+                pos = copy.copy(self.variant_position)
+                if length == 1:
+                    pos = self.variant_position
+                elif isinstance(self.variant_position, BaseOffsetInterval) and \
+                        self.variant_position.start.offset:
+                    pos.end.offset = pos.end.offset + length - 1
+
+                intronic_variant = hgvs_delins_parts_to_hgvs_obj(
+                        self.reference,
+                        self.prefix,
+                        pos,
+                        self.repeat_sequence,
+                        self.repeat_sequence,
+                        )
+                intronic_genomic_variant = self.no_norm_evm.t_to_g(intronic_variant)
+                self.g_strand = validator.hdp.get_tx_exons(
+                        intronic_variant.ac, intronic_genomic_variant.ac,
+                        validator.alt_aln_method)[0][3]
+                self.variant_position = intronic_genomic_variant.posedit.pos
+
+            self.intronic_g_reference = intronic_genomic_variant.ac
+            self.genomic_conversion = intronic_genomic_variant
+
+            # Check exon boundaries
+            self.check_exon_boundaries(validator)
+            within_ref_pos = intronic_genomic_variant.posedit.pos.start.base - 1
+            if self.g_strand == -1:
+                self.repeat_sequence = self.reverse_complement(self.repeat_sequence)
         # validate that the existing range matches the repeat given
         # then (re-)expand to full length and store in n type 1 based coordinates
         self.check_reference_sequence(validator, within_ref_pos)
         ref_start_position, ref_end_position = self.get_reference_range(validator, within_ref_pos)
         ref_start_position = ref_start_position + 1
-        full_range = f"{ref_start_position}_{ref_end_position}"
+        full_range = copy.copy(self.variant_position)
+        full_range.start.base = ref_start_position
+        full_range.end.base = ref_end_position
 
         # Map the full genomic range in the description
         if self.genomic_conversion is not None:
@@ -516,7 +591,7 @@ class TandemRepeats:
             ref = self.intronic_g_reference
         logger.info(
             f"Getting the full range of the variant: "
-            f"get_reference_range({ref}, {self.variant_position})"
+            f"get_reference_range({ref}, {str(self.variant_position)})"
         )
 
         # Get the full range of the reference repeat sequence
@@ -562,7 +637,7 @@ class TandemRepeats:
         logger.info(
             f"Reformatting variant: reformat({self.repeat_sequence}, "\
             f"{self.after_the_bracket}, "\
-            f"{self.prefix}, {self.variant_position}, {self.copy_number})"
+            f"{self.prefix}, {str(self.variant_position)}, {self.copy_number})"
         )
 
         if not self.copy_number.isdecimal():
@@ -586,7 +661,8 @@ class TandemRepeats:
                 f"Currently '{self.after_the_bracket}'' is included. "
             )
 
-        if re.search(r"[+-]", self.variant_position):
+        if isinstance(self.variant_position, BaseOffsetInterval) and (
+            self.variant_position.start.offset or self.variant_position.end.offset):
 
             # Create easy variant mapper (over variant mapper) and splign locked evm
             self.evm = AssemblyMapper(validator.hdp,
@@ -599,20 +675,30 @@ class TandemRepeats:
         # Add coordinates from start position (need range for intronic fall-back)
         self.variant_position = self.get_range_from_single_or_start_pos(validator)
         self.check_positions_given(validator)
-        self.variant_position = self.convert_n_to_c_coordinates()
         # Map back to transcript if intronic
         if self.genomic_conversion is not None:
             transcript_variant = self.evm.g_to_t(self.genomic_conversion, self.reference)
             self.reference = transcript_variant.ac
-            self.variant_position = str(transcript_variant.posedit.pos)
+            self.variant_position = transcript_variant.posedit.pos
             if self.g_strand == -1:
-                self.reverse_complement(self.repeat_sequence)
+                self.repeat_sequence = self.reverse_complement(self.repeat_sequence)
+                self.reference_sequence_bases =  self.reverse_complement(
+                        self.reference_sequence_bases)
+        else:
+            self._get_c_tx_info(validator)
+            self.variant_position = self.convert_n_to_c_coordinates()
+        # set inside of get_range_from_single_or_start_pos or equivalent
+        ref = self.reference_sequence_bases
 
-        final_format = f"{self.reference}:{self.prefix}." \
-                       f"{self.variant_position}{self.repeat_sequence}" \
-                       f"[{self.copy_number}]"
+        final_hgvs = hgvs_delins_parts_to_hgvs_obj(
+                self.reference,
+                self.prefix,
+                self.variant_position,
+                ref,
+                f"{self.repeat_sequence * int(self.copy_number)}")
+        final_hgvs.posedit.expanded_rep = self.repeat_sequence
 
-        return final_format
+        return final_hgvs
 
     def _get_c_tx_info(self,validator):
         """
@@ -628,11 +714,10 @@ class TandemRepeats:
         """
         if not self.prefix == "c":
             return
-        if self.cds_start is not None:
+        if self._c_to_n_tx_maper is not None:
             return
-        transcript_info = validator.hdp.get_tx_identity_info(self.reference)
-        self.cds_start = int(transcript_info[3])
-        self.cds_end = int(transcript_info[4])
+        self._c_to_n_tx_maper = AlignmentMapper(
+                validator.hdp, self.reference, self.reference, "transcript")
 
 
     def convert_n_to_c_coordinates(self):
@@ -644,52 +729,26 @@ class TandemRepeats:
         """
         logger.info(
             "Applying c type offset to n type coordinates: " +
-            f"convert_n_to_c_coordinates({self.variant_position})"
+            f"convert_n_to_c_coordinates({str(self.variant_position)})"
         )
-        if not self.prefix == 'c' or not self.cds_start:
+        if not self.prefix == 'c':
             return self.variant_position
-        start, _sep, end = self.variant_position.partition("_")
-        start = self._add_offset_to_n(start)
-        end = self._add_offset_to_n(end)
-        return f"{start}_{end}"
+        return self._c_to_n_tx_maper.n_to_c(self.variant_position)
 
-    def _add_offset_to_n(self,coridinate):
-        "Add c type offset to a single n type hgvs coordinate"
-        if int(coridinate) > self.cds_end:
-             coridinate = int(coridinate) - self.cds_end
-             return '*' + str(coridinate)
-        coridinate = int(coridinate) - self.cds_start
-        # for CDS start 0 would be first base pre CDS
-        if coridinate <= 0:
-            coridinate = coridinate - 1
-        return coridinate
-
-    def convert_c_to_n_coordinates(self,):
+    def convert_c_to_n_coordinates(self, pos=None):
         """
         Removes the offset from c type offset variant positions
         _get_c_tx_info must be called before this function is
         used.
         """
+        if pos is None:
+            pos = self.variant_position
         logger.info(
-            f"Removing offset: remove_offset({self.variant_position})"
+            f"Removing offset: remove_offset({str(self.variant_position)})"
         )
-        if not self.prefix == 'c' or not self.cds_start:
-            return self.variant_position
-        start, _sep, end = self.variant_position.partition("_")
-        start = self._de_offset_c(start)
-        if not end:
-            return str(start)
-        end = self._de_offset_c(end)
-        return f"{start}_{end}"
-
-    def _de_offset_c(self,coridinate):
-        "De-offset a single c type hgvs coordinate"
-        if coridinate.startswith('*'):
-            return int(coridinate[1:]) + self.cds_end
-        if coridinate.startswith('-'):
-            return int(coridinate) + self.cds_start + 1
-        else:
-            return int(coridinate) + self.cds_start
+        if not self.prefix == 'c':
+            return pos
+        return self._c_to_n_tx_maper.c_to_n(pos)
 
     def reverse_complement(self, dna_seq):
         """
@@ -698,102 +757,92 @@ class TandemRepeats:
         :return: (str)
         """
         reverse_seq = dna_seq[::-1]
-        self.repeat_sequence = "".join([{"G": "C", "T": "A", "A": "T", "C": "G",
+        return "".join([{"G": "C", "T": "A", "A": "T", "C": "G",
                                          "g": "c", "t": "a", "a": "t", "c": "g"}[base]
                                         for base in list(reverse_seq)])
-        return
 
     def check_exon_boundaries(self,validator):
         """
         Check the boundaries of intronic variants are correctly stated
         """
         logger.info(
-            f"Checking intronic variant boundaries: check_exon_boundaries({self.variant_position})"
+            "Checking intronic variant boundaries: "+
+            f"check_exon_boundaries({str(self.original_position)})"
         )
         # Return without error if no boundaries used
-        if not '+' in self.original_position and not (
-            '-' in self.original_position and # only bother to check with regex if relevant
-            re.search('[0-9]-',self.original_position)):
+        if not isinstance(self.original_position, BaseOffsetInterval) or (
+            isinstance(self.original_position, BaseOffsetInterval) and not (
+                self.original_position.start.offset or
+                self.original_position.end.offset)):
             return
 
         exon_data = validator.hdp.get_tx_exons(self.reference,
                                                self.genomic_conversion.ac,
                                                validator.alt_aln_method)
         transcript_exon_pos = []
-        if  self.prefix == 'c' and self.cds_start is None:
-            transcript_info = validator.hdp.get_tx_identity_info(self.reference)
-            self.cds_start = int(transcript_info[3])
-        elif self.cds_start is None:
-            self.cds_start = 0
+        if  self.prefix == 'c':
+            self._get_c_tx_info(validator)
+            pos = self.convert_c_to_n_coordinates(pos=self.original_position)
+        else:
+            pos = self.original_position
 
         for exon in exon_data:
             transcript_exon_pos.append(exon['tx_end_i'])
-        start, _sep, end = self.original_position.partition('_')
         def check_exon_pos(exon_pos):
+            if not exon_pos.offset:
+                return True
             bad_exon = False
-            if exon_pos.startswith('-') and ('+' in exon_pos or '-' in start[1:]):
-                pos, _sep, offset = start[1:].partition('-')
-                if not self.cds_start - int(pos) -1 in transcript_exon_pos:
-                    bad_exon = True
-            elif '-' in exon_pos:
-                pos, _sep, offset = exon_pos.partition('-')
-                if not int(pos) + self.cds_start -1 in transcript_exon_pos:
-                    bad_exon = True
-            elif '+' in exon_pos:
-                pos, _sep, offset = exon_pos.partition('+')
-                if pos.startswith('-'):
-                    pos = self.cds_start - int(pos)
-                else:
-                    pos = self.cds_start + int(pos)
-                if not pos in transcript_exon_pos:
-                    bad_exon = True
+            if exon_pos.offset < 0 and exon_pos.base -1 not in transcript_exon_pos:
+                bad_exon = True
+            elif exon_pos.offset > 0 and exon_pos.base not in transcript_exon_pos:
+                bad_exon = True
             if bad_exon:
                 raise RepeatSyntaxError(
-                    f"ExonBoundaryError: Position {self.original_position} " +
+                    f"ExonBoundaryError: Position {str(self.original_position)} " +
                     "does not correspond with an exon boundary for transcript "
                     + self.reference)
             return True
-        check_exon_pos(start)
+        check_exon_pos(pos.start)
         # skip "end" if we don't have a range
-        if not end:
+        if pos.end == pos.start:
             return
-        check_exon_pos(end)
-        return
+        check_exon_pos(pos.end)
 
 
 def convert_tandem(variant, validator, build, my_all):
+    "convenience function to encapsulate TandemRepeats->VV integration"
     try:
-        expanded_variant = TandemRepeats.parse_repeat_variant(variant.quibble, build, my_all, validator)
+        expanded_variant = TandemRepeats.parse_repeat_variant(
+                variant.quibble, build, my_all, validator)
     except AttributeError:
-        expanded_variant = TandemRepeats.parse_repeat_variant(variant, build, my_all, validator)
+        expanded_variant = TandemRepeats.parse_repeat_variant(
+                variant, build, my_all, validator)
 
     if expanded_variant is False:
         return False
-    else:
-        expanded_variant_string = expanded_variant.reformat(validator)
+    expanded_var_hgvs_obj = expanded_variant.reformat(validator)
 
-
-        try:
-            variant.expanded_repeat = {"variant": expanded_variant_string,
-                                       "position": expanded_variant.variant_position,
-                                       "copy_number": expanded_variant.copy_number,
-                                       "repeat_sequence": expanded_variant.repeat_sequence,
-                                       "reference": expanded_variant.reference,
-                                       "prefix": expanded_variant.prefix,
-                                       "reference_sequence_bases": expanded_variant.reference_sequence_bases}
-            logger.info(f"variant.expanded_repeat: {variant.expanded_repeat}")
-        except AttributeError:
-            expanded_repeat = {"variant": expanded_variant_string,
-                               "position": expanded_variant.variant_position,
-                               "copy_number": expanded_variant.copy_number,
-                               "repeat_sequence": expanded_variant.repeat_sequence,
-                               "reference": expanded_variant.reference,
-                               "prefix": expanded_variant.prefix,
-                               "reference_sequence_bases": expanded_variant.reference_sequence_bases}
-            logger.info(f"expanded_repeat: {expanded_repeat}")
-            return expanded_repeat
-
-        return True
+    try:
+        variant.expanded_repeat = {
+                "variant": expanded_var_hgvs_obj,
+                "position": expanded_variant.variant_position,
+                "copy_number": expanded_variant.copy_number,
+                "repeat_sequence": expanded_variant.repeat_sequence,
+                "reference": expanded_variant.reference,
+                "prefix": expanded_variant.prefix,
+                "reference_sequence_bases": expanded_variant.reference_sequence_bases}
+        logger.info(f"variant.expanded_repeat: {variant.expanded_repeat}")
+    except AttributeError:
+        expanded_repeat = {"variant": expanded_var_hgvs_obj,
+                           "position": expanded_variant.variant_position,
+                           "copy_number": expanded_variant.copy_number,
+                           "repeat_sequence": expanded_variant.repeat_sequence,
+                           "reference": expanded_variant.reference,
+                           "prefix": expanded_variant.prefix,
+                           "reference_sequence_bases": expanded_variant.reference_sequence_bases}
+        logger.info(f"expanded_repeat: {expanded_repeat}")
+        return expanded_repeat
+    return True
 
 
 # <LICENSE>

--- a/VariantValidator/modules/format_converters.py
+++ b/VariantValidator/modules/format_converters.py
@@ -208,7 +208,6 @@ def vcf2hgvs_stage1(variant, validator):
         validator.batch_list.append(query_a)
         validator.batch_list.append(query_b)
         logger.info("Submitting new variant with format %s", input_a)
-        logger.info("Submitting new variant with format %s", input_b)
         skipvar = True
     elif vcf_data[3]:
         variant.quibble = f'{vcf_data[0]}:{vcf_data[1]}ins{vcf_data[3]}'
@@ -747,18 +746,22 @@ def convert_expanded_repeat(my_variant, validator):
     ins_bases = (my_variant.expanded_repeat["repeat_sequence"] *
                  int(my_variant.expanded_repeat["copy_number"]))
     start_pos, _sep, end_pos = my_variant.expanded_repeat['position'].partition('_')
+
     repeat_to_delins = hgvs_delins_parts_to_hgvs_obj(
             my_variant.expanded_repeat['reference'],
             my_variant.expanded_repeat['prefix'],
             start_pos,
-            '',
+            my_variant.expanded_repeat['reference_sequence_bases'],
             ins_bases,
             end=end_pos)
+
+    logger.info(f"Expanded repeat to delins raw: {repeat_to_delins}")
 
     try:
         repeat_to_delins = my_variant.hn.normalize(repeat_to_delins)
     except vvhgvs.exceptions.HGVSUnsupportedOperationError:
         pass
+    logger.info(f"Expanded repeat to delins normalised: {repeat_to_delins}")
     my_variant.quibble = repeat_to_delins #fn.valstr(repeat_to_delins)
     my_variant.warnings.append(f"ExpandedRepeatWarning: {my_variant.expanded_repeat['variant']} "
                                f"should only be used as an annotation for the core "

--- a/VariantValidator/modules/format_converters.py
+++ b/VariantValidator/modules/format_converters.py
@@ -732,30 +732,20 @@ def convert_expanded_repeat(my_variant, validator):
         if not has_ex_repeat:
             return False
 
-    if my_variant.quibble != my_variant.expanded_repeat["variant"]:
+    if my_variant.quibble != str(my_variant.expanded_repeat["variant"]):
         if re.search("\d+_", my_variant.quibble):
             my_variant.warnings.append(f"ExpandedRepeatError: The coordinates for the repeat region are stated incorrectly"
                                        f" in the submitted description {my_variant.quibble}. The corrected format"
-                                       f" would be {my_variant.expanded_repeat['variant'].split('[')[0]}"
+                                       f" would be {str(my_variant.expanded_repeat['variant']).split('[')[0]}"
                                        f"[int], where int requires you to update the number of repeats")
             return True
         else:
             my_variant.warnings.append(f"ExpandedRepeatError: The coordinates for the repeat region are stated incorrectly"
                                        f" in the submitted description {my_variant.quibble}. The corrected description is "
-                                       f"{my_variant.expanded_repeat['variant']}")
-    ins_bases = (my_variant.expanded_repeat["repeat_sequence"] *
-                 int(my_variant.expanded_repeat["copy_number"]))
-    start_pos, _sep, end_pos = my_variant.expanded_repeat['position'].partition('_')
+                                       f"{str(my_variant.expanded_repeat['variant'])}")
 
-    repeat_to_delins = hgvs_delins_parts_to_hgvs_obj(
-            my_variant.expanded_repeat['reference'],
-            my_variant.expanded_repeat['prefix'],
-            start_pos,
-            my_variant.expanded_repeat['reference_sequence_bases'],
-            ins_bases,
-            end=end_pos)
-
-    logger.info(f"Expanded repeat to delins raw: {repeat_to_delins}")
+    repeat_to_delins = copy.deepcopy(my_variant.expanded_repeat["variant"])
+    repeat_to_delins.posedit.expanded_rep = False
 
     try:
         repeat_to_delins = my_variant.hn.normalize(repeat_to_delins)

--- a/VariantValidator/modules/gene2transcripts.py
+++ b/VariantValidator/modules/gene2transcripts.py
@@ -121,7 +121,7 @@ def gene2transcripts(g2t, query, validator=False, bypass_web_searches=False, sel
                                     tx_info[3],
                                     0,
                                     query.hgvs_coding.ac,
-                                    query.primary_assembly_loci[builds]['hgvs_genomic_description'].split(":")[0],
+                                    query.primary_assembly_loci[builds]['hgvs_genomic_description'].ac,
                                     validator.alt_aln_method])
 
         # Add refseqgene if available

--- a/VariantValidator/modules/liftover.py
+++ b/VariantValidator/modules/liftover.py
@@ -24,11 +24,6 @@ logger = logging.getLogger(__name__)
 
 LO_CACHE = {}
 
-def mystr(hgvs_nucleotide):
-    hgvs_nucleotide_refless = hgvs_nucleotide.format({'max_ref_length': 0})
-    return hgvs_nucleotide_refless
-
-
 def liftover(hgvs_genomic, build_from, build_to, hn, reverse_normalizer, evm, validator,
              specify_tx=False, liftover_level=False, g_to_g=False, gap_map=False, vfo=False,
              specified_tx_variant=False, genomic_data_w_vcf=False, force_pyliftover=False):
@@ -129,7 +124,7 @@ def liftover(hgvs_genomic, build_from, build_to, hn, reverse_normalizer, evm, va
                                               reverse_normalizer, validator.sf)
         lifted_response[build_from.lower()] = {}
         lifted_response[build_from.lower()][hgvs_genomic.ac] = {
-                'hgvs_genomic_description': mystr(hgvs_genomic),
+                'hgvs_genomic_description': hgvs_genomic,
                 'vcf': {
                     'chr': from_vcf[from_set],
                     'pos': str(from_vcf['pos']),
@@ -139,7 +134,7 @@ def liftover(hgvs_genomic, build_from, build_to, hn, reverse_normalizer, evm, va
                 }
         lifted_response[alt_build_from.lower()] = {}
         lifted_response[alt_build_from.lower()][hgvs_genomic.ac] = {
-                'hgvs_genomic_description': mystr(hgvs_genomic),
+                'hgvs_genomic_description': hgvs_genomic,
                 'vcf': {
                     'chr': from_vcf[alt_from_set],
                     'pos': str(from_vcf['pos']),
@@ -249,12 +244,13 @@ def liftover(hgvs_genomic, build_from, build_to, hn, reverse_normalizer, evm, va
                     # Gap compensation edit for the VariantFormatter pathway
                     if gap_map is not False and build_from not in val:
                         # Set genome assembly for gap mapping
-                        get_assembly = seq_data.supported_for_mapping(key, "GRCh37")
-                        if get_assembly is True:
-                            map_to_assembly = "GRCh37"
                         get_assembly = seq_data.supported_for_mapping(key, "GRCh38")
                         if get_assembly is True:
                             map_to_assembly = "GRCh38"
+                        else:
+                            get_assembly = seq_data.supported_for_mapping(key, "GRCh37")
+                            if get_assembly is True:
+                                map_to_assembly = "GRCh37"
 
                         # Reset HGVS Alt Genomic
                         no_norm_evm = AssemblyMapper(
@@ -312,7 +308,7 @@ def liftover(hgvs_genomic, build_from, build_to, hn, reverse_normalizer, evm, va
                     # Add the to build dictionaries
                     if val[1] == build_to:
                         lifted_response[build_to.lower()][hgvs_alt_genomic.ac] = {
-                            'hgvs_genomic_description': mystr(hgvs_alt_genomic),
+                            'hgvs_genomic_description': hgvs_alt_genomic,
                             'vcf': {
                                 'chr': alt_vcf[to_set],
                                 'pos': str(alt_vcf['pos']),
@@ -320,9 +316,10 @@ def liftover(hgvs_genomic, build_from, build_to, hn, reverse_normalizer, evm, va
                                 'alt': alt_vcf['alt']
                             }
                         }
+                        added_data = True
                     if val[2] == alt_build_to:
                         lifted_response[alt_build_to.lower()][hgvs_alt_genomic.ac] = {
-                            'hgvs_genomic_description': mystr(hgvs_alt_genomic),
+                            'hgvs_genomic_description': hgvs_alt_genomic,
                             'vcf': {
                                 'chr': alt_vcf[alt_to_set],
                                 'pos': str(alt_vcf['pos']),
@@ -330,6 +327,7 @@ def liftover(hgvs_genomic, build_from, build_to, hn, reverse_normalizer, evm, va
                                 'alt': alt_vcf['alt']
                             }
                         }
+                        added_data = True
                     # Overwrite build from info as PAR may require additional info
                     if val[2] == alt_build_from or val[1] == build_from:
                         alt_vcf_b = hgvs_utils.report_hgvs2vcf(
@@ -339,7 +337,7 @@ def liftover(hgvs_genomic, build_from, build_to, hn, reverse_normalizer, evm, va
                                 validator.sf)
                     if val[1] == build_from:
                         lifted_response[build_from.lower()][hgvs_alt_genomic.ac] = {
-                            'hgvs_genomic_description': mystr(hgvs_alt_genomic),
+                            'hgvs_genomic_description': hgvs_alt_genomic,
                             'vcf': {
                                 'chr': alt_vcf_b[to_set],
                                 'pos': str(alt_vcf_b['pos']),
@@ -349,7 +347,7 @@ def liftover(hgvs_genomic, build_from, build_to, hn, reverse_normalizer, evm, va
                         }
                     if val[2] == alt_build_from:
                         lifted_response[alt_build_from.lower()][hgvs_alt_genomic.ac] = {
-                            'hgvs_genomic_description': mystr(hgvs_alt_genomic),
+                            'hgvs_genomic_description': hgvs_alt_genomic,
                             'vcf': {
                                 'chr': alt_vcf_b[alt_to_set],
                                 'pos': str(alt_vcf_b['pos']),
@@ -366,8 +364,6 @@ def liftover(hgvs_genomic, build_from, build_to, hn, reverse_normalizer, evm, va
                         pass
                     except NameError:
                         pass
-
-                    added_data = True
 
                 except vvhgvs.exceptions.HGVSError:
                     continue
@@ -563,7 +559,7 @@ def liftover(hgvs_genomic, build_from, build_to, hn, reverse_normalizer, evm, va
                             if mito_build is False:
                                 if build.startswith('GRC'):
                                     lifted_response[build_to.lower()][hgvs_lifted.ac] = {
-                                        'hgvs_genomic_description': mystr(hgvs_lifted),
+                                        'hgvs_genomic_description': hgvs_lifted,
                                         'vcf': {'chr': vcf_dict['grc_chr'],
                                                 'pos': str(vcf_dict['pos']),
                                                 'ref': vcf_dict['ref'],
@@ -572,7 +568,7 @@ def liftover(hgvs_genomic, build_from, build_to, hn, reverse_normalizer, evm, va
                                     }
 
                                     lifted_response[alt_build_to.lower()][hgvs_lifted.ac] = {
-                                        'hgvs_genomic_description': mystr(hgvs_lifted),
+                                        'hgvs_genomic_description': hgvs_lifted,
                                         'vcf': {'chr': vcf_dict['ucsc_chr'],
                                                 'pos': str(vcf_dict['pos']),
                                                 'ref': vcf_dict['ref'],
@@ -582,7 +578,7 @@ def liftover(hgvs_genomic, build_from, build_to, hn, reverse_normalizer, evm, va
 
                                 else:
                                     lifted_response[build_to.lower()][hgvs_lifted.ac] = {
-                                        'hgvs_genomic_description': mystr(hgvs_lifted),
+                                        'hgvs_genomic_description': hgvs_lifted,
                                         'vcf': {'chr': vcf_dict['ucsc_chr'],
                                                 'pos': str(vcf_dict['pos']),
                                                 'ref': vcf_dict['ref'],
@@ -591,7 +587,7 @@ def liftover(hgvs_genomic, build_from, build_to, hn, reverse_normalizer, evm, va
                                     }
 
                                     lifted_response[alt_build_to.lower()][hgvs_lifted.ac] = {
-                                        'hgvs_genomic_description': mystr(hgvs_lifted),
+                                        'hgvs_genomic_description': hgvs_lifted,
                                         'vcf': {'chr': vcf_dict['grc_chr'],
                                                 'pos': str(vcf_dict['pos']),
                                                 'ref': vcf_dict['ref'],
@@ -602,7 +598,7 @@ def liftover(hgvs_genomic, build_from, build_to, hn, reverse_normalizer, evm, va
                             else:
                                 if mito_build.startswith('GRC'):
                                     lifted_response[mito_build.lower()][hgvs_lifted.ac] = {
-                                        'hgvs_genomic_description': mystr(hgvs_lifted),
+                                        'hgvs_genomic_description': hgvs_lifted,
                                         'vcf': {'chr': vcf_dict['grc_chr'],
                                                 'pos': str(vcf_dict['pos']),
                                                 'ref': vcf_dict['ref'],
@@ -612,7 +608,7 @@ def liftover(hgvs_genomic, build_from, build_to, hn, reverse_normalizer, evm, va
 
                                     if lifted_response["grch38"] == {}:
                                         lifted_response["grch38"][hgvs_lifted.ac] = {
-                                            'hgvs_genomic_description': mystr(hgvs_lifted),
+                                            'hgvs_genomic_description': hgvs_lifted,
                                             'vcf': {'chr': vcf_dict['grc_chr'],
                                                     'pos': str(vcf_dict['pos']),
                                                     'ref': vcf_dict['ref'],
@@ -620,7 +616,7 @@ def liftover(hgvs_genomic, build_from, build_to, hn, reverse_normalizer, evm, va
                                                     }
                                         }
                                         lifted_response["hg38"][hgvs_lifted.ac] = {
-                                            'hgvs_genomic_description': mystr(hgvs_lifted),
+                                            'hgvs_genomic_description': hgvs_lifted,
                                             'vcf': {'chr': 'chrM',
                                                     'pos': str(vcf_dict['pos']),
                                                     'ref': vcf_dict['ref'],
@@ -630,7 +626,7 @@ def liftover(hgvs_genomic, build_from, build_to, hn, reverse_normalizer, evm, va
 
                                 else:
                                     lifted_response[mito_build.lower()][hgvs_lifted.ac] = {
-                                        'hgvs_genomic_description': mystr(hgvs_lifted),
+                                        'hgvs_genomic_description': hgvs_lifted,
                                         'vcf': {'chr': vcf_dict['ucsc_chr'],
                                                 'pos': str(vcf_dict['pos']),
                                                 'ref': vcf_dict['ref'],

--- a/VariantValidator/modules/mappers.py
+++ b/VariantValidator/modules/mappers.py
@@ -223,7 +223,8 @@ def gene_to_transcripts(variant, validator, select_transcripts_dict):
 
             query = Variant(variant.original, quibble=c_description, warnings=variant.warnings + gap_warnings,
                             primary_assembly=variant.primary_assembly, order=variant.order,
-                            selected_assembly=variant.selected_assembly, reformat_output=variant.reformat_output)
+                            selected_assembly=variant.selected_assembly, reformat_output=variant.reformat_output,
+                            expanded_repeat=variant.expanded_repeat)
             validator.batch_list.append(query)
             logger.info("Submitting new variant with format %s", str(c_description))
 

--- a/VariantValidator/modules/seq_state_to_expanded_repeat.py
+++ b/VariantValidator/modules/seq_state_to_expanded_repeat.py
@@ -142,7 +142,7 @@ def decipher_end_of_full_reference_repeated_sequence(reference, repeated_unit, s
 
     return None
 
-def convert_seq_state_to_expanded_repeat(variant, validator, genomic_reference=None):
+def convert_seq_state_to_expanded_repeat(variant, validator, genomic_reference=None, known_repeat_unit=None):
     """
     Main interface: convert a HGVS variant string to an expanded repeat representation.
 
@@ -205,7 +205,13 @@ def convert_seq_state_to_expanded_repeat(variant, validator, genomic_reference=N
             variant_type = 'ins'
             start, end = map(int, position.split('_'))
             logger.info(f"Detected {variant_type} at position {start} to {end} with sequence {sequence}")
-            repeated_unit = decipher_repeated_unit(sequence)
+            if known_repeat_unit is None:
+                repeated_unit = decipher_repeated_unit(sequence)
+            else:
+                if known_repeat_unit in sequence:
+                    repeated_unit = known_repeat_unit
+                else:
+                    repeated_unit = validator.revcomp(known_repeat_unit)
             logger.info(f"Repeated unit: {repeated_unit}")
             reference_start = decipher_start_of_full_reference_repeated_sequence(reference, repeated_unit, start,
                                                                                  validator)
@@ -221,7 +227,14 @@ def convert_seq_state_to_expanded_repeat(variant, validator, genomic_reference=N
             seq_state_info = seq_state_info.replace('=', "")
             position, sequence = re.split(r'(?<=\d)(?=[A-Za-z])', seq_state_info)
             start, end = map(int, position.split('_'))
-            repeated_unit = decipher_repeated_unit(sequence)
+            if known_repeat_unit is None:
+                repeated_unit = decipher_repeated_unit(sequence)
+            else:
+                if known_repeat_unit in sequence:
+                    repeated_unit = known_repeat_unit
+                else:
+                    repeated_unit = validator.revcomp(known_repeat_unit)
+            logger.info(f"Repeated unit: {repeated_unit}")
             reference_start = decipher_start_of_full_reference_repeated_sequence(reference, repeated_unit, start, validator)
             reference_end = decipher_end_of_full_reference_repeated_sequence(reference, repeated_unit, start, validator)
 
@@ -238,7 +251,14 @@ def convert_seq_state_to_expanded_repeat(variant, validator, genomic_reference=N
             original_sequence = sequence
             sequence *= 2  # Expand the duplication so it resembles an insertion
             start, end = map(int, position.split('_'))
-            repeated_unit = decipher_repeated_unit(sequence)
+            if known_repeat_unit is None:
+                repeated_unit = decipher_repeated_unit(sequence)
+            else:
+                if known_repeat_unit in sequence:
+                    repeated_unit = known_repeat_unit
+                else:
+                    repeated_unit = validator.revcomp(known_repeat_unit)
+            logger.info(f"Repeated unit: {repeated_unit}")
             reference_start = decipher_start_of_full_reference_repeated_sequence(reference, repeated_unit, start, validator)
             reference_end = decipher_end_of_full_reference_repeated_sequence(reference, repeated_unit, start, validator)
             return reassemble_expanded_repeat_variant(reference, reference_start, reference_end, reference_type,
@@ -250,7 +270,14 @@ def convert_seq_state_to_expanded_repeat(variant, validator, genomic_reference=N
         elif "del" in seq_state_info:
             position, sequence = seq_state_info.split('del')
             start, end = map(int, position.split('_'))
-            repeated_unit = decipher_repeated_unit(sequence)
+            if known_repeat_unit is None:
+                repeated_unit = decipher_repeated_unit(sequence)
+            else:
+                if known_repeat_unit in sequence:
+                    repeated_unit = known_repeat_unit
+                else:
+                    repeated_unit = validator.revcomp(known_repeat_unit)
+            logger.info(f"Repeated unit: {repeated_unit}")
             reference_start = decipher_start_of_full_reference_repeated_sequence(reference, repeated_unit, start, validator)
             reference_end = decipher_end_of_full_reference_repeated_sequence(reference, repeated_unit, start, validator)
             remove_units = len(sequence) // len(repeated_unit)

--- a/VariantValidator/modules/seq_state_to_expanded_repeat.py
+++ b/VariantValidator/modules/seq_state_to_expanded_repeat.py
@@ -263,6 +263,13 @@ def convert_seq_state_to_expanded_repeat(variant, validator, genomic_reference=N
     raise VariantFormatError("Variant must be an HGVS-formatted string of type 'ins', 'del', 'dup', or '='.")
 
 
+if __name__ == '__main__':
+    import VariantValidator
+    validator = VariantValidator.Validator()
+    result = convert_seq_state_to_expanded_repeat("NM_002111.8:c.54_116=", validator, genomic_reference="NC_000004.11")
+    print(result)
+
+
 # <LICENSE>
 # Copyright (C) 2016-2025 VariantValidator Contributors
 #

--- a/VariantValidator/modules/seq_state_to_expanded_repeat.py
+++ b/VariantValidator/modules/seq_state_to_expanded_repeat.py
@@ -1,0 +1,281 @@
+import logging
+import re
+from VariantValidator.modules import utils
+
+# Custom exceptions for better error granularity
+class RepeatedUnitError(Exception):
+    """Raised when the repeated unit is empty or invalid."""
+    pass
+
+class StartPositionError(Exception):
+    """Raised when the start position is missing or invalid."""
+    pass
+
+class VariantFormatError(Exception):
+    """Raised when the variant type is not recognized or improperly formatted."""
+    pass
+
+class VariantDataError(Exception):
+    """Raised when the variant data is incomplete or malformed."""
+    pass
+
+logger = logging.getLogger(__name__)
+
+
+def reassemble_expanded_repeat_variant(reference, reference_start, reference_end, reference_type,
+                                       repeated_unit, inserted_sequence, validator, remove_units=0,
+                                       converted_from_intronic=False, alt_aln_method=None):
+    """
+    Assemble the final expanded repeat representation in HGVS-like format.
+
+    Example: NG_012232.1:g.3_6T[20]
+
+    Args explain how all parts are used to compute total repeat count.
+    """
+    if not repeated_unit:
+        raise RepeatedUnitError("Repeated unit must be a non-empty string.")
+
+    unit_len = len(repeated_unit)
+    inserted_repeat_units = len(inserted_sequence) // unit_len
+    reference_repeat_units = (reference_end - reference_start + 1) // unit_len
+    total_units = reference_repeat_units + inserted_repeat_units - remove_units
+
+    # Begin constructing the variant with positional metadata
+
+    if converted_from_intronic is False:
+        variant_identity_format = f"{reference}:{reference_type}{reference_start}_{reference_end}="
+    else:
+        variant_identity_format = f"{reference}:g.{reference_start}_{reference_end}="
+
+    # If the variant is coding (c.), convert to nucleotide (n.) and back to ensure alignment
+    if reference_type == "c." and "NC_" not in reference:
+        reparse = validator.hp.parse(variant_identity_format.replace("c.", "n."))
+        variant_identity_format = utils.valstr(validator.vm.n_to_c(reparse))
+
+    elif converted_from_intronic is not False:
+        variant_identity_format = utils.valstr(validator.vm.g_to_t(validator.hp.parse(variant_identity_format), converted_from_intronic,
+                                                                   alt_aln_method=alt_aln_method))
+        orientation = validator.hdp.get_tx_exons(converted_from_intronic, reference, alt_aln_method=alt_aln_method)[0][3]
+        if orientation != 1:
+            # If the transcript is on the reverse strand, we need reverse complement the repeat bases
+            repeated_unit = validator.revcomp(repeated_unit)
+
+    # Replace = with actual repeat structure like T[20]
+    return variant_identity_format.replace("=", f"{repeated_unit}[{total_units}]")
+
+def decipher_repeated_unit(sequence):
+    """
+    Detect the smallest unit that repeats to form the given DNA sequence.
+    If no repeat unit found, return the original sequence.
+    """
+    n = len(sequence)
+    for unit_len in range(1, n // 2 + 1):
+        unit = sequence[:unit_len]
+        multiplier = n // unit_len
+        if unit * multiplier == sequence[:unit_len * multiplier]:
+            return unit
+    return sequence  # Default: no recognizable repeat pattern
+
+def decipher_start_of_full_reference_repeated_sequence(reference, repeated_unit, start, validator):
+    """
+    Given a position where a repeat starts, walk backwards to find the full beginning of the repeat block.
+    """
+    if not repeated_unit:
+        raise RepeatedUnitError("Repeated unit must be a non-empty string.")
+    if start is None or not isinstance(start, int) or start <= 0:
+        raise StartPositionError("Start position must be a positive integer.")
+
+    unit_len = len(repeated_unit)
+    l_start = start - 1  # convert to 0-based
+    current_chunk = validator.sf.fetch_seq(reference, start_i=l_start, end_i=l_start + unit_len)
+
+    if current_chunk != repeated_unit:
+        return None  # Repeat does not match expected unit
+
+    while l_start - unit_len >= 0:
+        prev_chunk = validator.sf.fetch_seq(reference, start_i=l_start - unit_len, end_i=l_start)
+        if prev_chunk != repeated_unit:
+            break
+        l_start -= unit_len
+
+    return l_start + 1  # convert back to 1-based
+
+def decipher_end_of_full_reference_repeated_sequence(reference, repeated_unit, start, validator):
+    """
+    Walk forward from a given repeat position to find the full extent of the repeated block.
+    Tries two possible offsets to ensure frame alignment.
+    """
+    if not repeated_unit:
+        raise RepeatedUnitError("Repeated unit must be a non-empty string.")
+    if start is None or not isinstance(start, int) or start <= 0:
+        raise StartPositionError("Start position must be a positive integer.")
+
+    unit_len = len(repeated_unit)
+    start_0_try1 = start - 1 - unit_len  # one repeat length before start
+    start_0_try2 = start - 1             # direct match at start
+
+    for start_0 in [start_0_try1, start_0_try2]:
+        if start_0 < 0:
+            continue
+
+        try:
+            chunk = validator.sf.fetch_seq(reference, start_i=start_0, end_i=start_0 + unit_len)
+        except Exception:
+            continue
+
+        if chunk != repeated_unit:
+            continue
+
+        pos = start_0
+        while True:
+            next_start = pos + unit_len
+            next_end = next_start + unit_len
+            try:
+                next_chunk = validator.sf.fetch_seq(reference, start_i=next_start, end_i=next_end)
+            except Exception:
+                break
+            if next_chunk != repeated_unit:
+                break
+            pos += unit_len
+
+        return pos + unit_len  # return 1-based end position
+
+    return None
+
+def convert_seq_state_to_expanded_repeat(variant, validator, genomic_reference=None):
+    """
+    Main interface: convert a HGVS variant string to an expanded repeat representation.
+
+    Supports: insertions (ins), deletions (del), duplications (dup), identity (=)
+    """
+    if any(key in variant for key in ['ins', 'del', 'dup', '=']):
+        hgvs_variant = validator.hp.parse(variant)
+        # Use ENST normalizer or splign depending on variant format
+        hn = validator.genebuild_normalizer if "ENST" in variant else validator.splign_normalizer
+        alt_aln_method = "genebuild" if "ENST" in variant else "splign"
+        hgvs_variant = hn.normalize(hgvs_variant)
+
+        # Determine reference type and extract sequence info
+        converted_from_intronic = False
+        if ":g." in variant:
+            reference_type = "g."
+            parts = str(hgvs_variant).split(':g.')
+        elif ":c." in variant or ":n." in variant:
+            if ":c." in variant:
+                reference_type = "c."
+                hgvs_n = validator.vm.c_to_n(hgvs_variant)
+            elif ":n." in variant:
+                hgvs_n = hgvs_variant
+                reference_type = "n."
+            logger.info(f"variant is a transcript variant {variant}")
+            parts = str(hgvs_n).split(':n.')
+            logger.info(f"Converted to n. coordinates: {hgvs_n}")
+
+            # For intronic variants, we need to ensure need to do some extra processing
+            if ((hgvs_n.posedit.pos.start.offset != 0 or hgvs_n.posedit.pos.end.offset != 0) and
+                    genomic_reference is None):
+                raise VariantFormatError(f"Intronic variants are currently not supported: {variant}")
+            elif ((hgvs_n.posedit.pos.start.offset != 0 or hgvs_n.posedit.pos.end.offset != 0) and
+                    genomic_reference is not None):
+                try:
+                    hgvs_genomic = validator.vm.t_to_g(hgvs_variant, genomic_reference, alt_aln_method=alt_aln_method)
+                except Exception:
+                    raise VariantFormatError(f"Unable to map intronic variant {variant} to "
+                                             f"genomic reference {genomic_reference}. ")
+                else:
+                    converted_from_intronic = hgvs_variant.ac
+                    logger.info(f"Converted to genomic coordinates: {hgvs_genomic}")
+                    if re.search("ins$", str(hgvs_genomic)) and re.search("=$", str(hgvs_variant)):
+                        hgvs_genomic.posedit.edit.alt = hgvs_genomic.posedit.edit.ref
+                    parts = str(hgvs_genomic).split(':g.')
+            logger.info(f"parts: {parts}")
+        else:
+            logger.error(f"Invalid variant format: {variant}")
+            raise VariantFormatError("Variant must contain one of ':g.', ':c.', or ':n.'")
+
+        if len(parts) != 2:
+            logger.error(f"Variant splitting failed. Got parts: {parts}")
+            raise VariantFormatError("Invalid variant format after split.")
+
+        reference, seq_state_info = parts
+
+        # Process insertions
+        if "ins" in seq_state_info:
+            position, sequence = seq_state_info.split('ins')
+            variant_type = 'ins'
+            start, end = map(int, position.split('_'))
+            logger.info(f"Detected {variant_type} at position {start} to {end} with sequence {sequence}")
+            repeated_unit = decipher_repeated_unit(sequence)
+            logger.info(f"Repeated unit: {repeated_unit}")
+            reference_start = decipher_start_of_full_reference_repeated_sequence(reference, repeated_unit, start,
+                                                                                 validator)
+            reference_end = decipher_end_of_full_reference_repeated_sequence(reference, repeated_unit, start, validator)
+            logger.info(f"Reference start position: {reference_start} and end position: {reference_end}")
+            return reassemble_expanded_repeat_variant(reference, reference_start, reference_end, reference_type,
+                                                      repeated_unit, sequence, validator,
+                                                      converted_from_intronic=converted_from_intronic,
+                                                      alt_aln_method=alt_aln_method)
+
+        # Process identity cases (=)
+        elif "=" in seq_state_info:
+            seq_state_info = seq_state_info.replace('=', "")
+            position, sequence = re.split(r'(?<=\d)(?=[A-Za-z])', seq_state_info)
+            start, end = map(int, position.split('_'))
+            repeated_unit = decipher_repeated_unit(sequence)
+            reference_start = decipher_start_of_full_reference_repeated_sequence(reference, repeated_unit, start, validator)
+            reference_end = decipher_end_of_full_reference_repeated_sequence(reference, repeated_unit, start, validator)
+
+            logger.info(f"Converted from {converted_from_intronic} to expanded repeat variant: {reference_start}, {reference_end}, {reference_type}, {repeated_unit}")
+
+            return reassemble_expanded_repeat_variant(reference, reference_start, reference_end, reference_type,
+                                                      repeated_unit, "", validator,
+                                                      converted_from_intronic=converted_from_intronic,
+                                                      alt_aln_method=alt_aln_method)
+
+        # Process duplications
+        elif "dup" in seq_state_info:
+            position, sequence = seq_state_info.split('dup')
+            original_sequence = sequence
+            sequence *= 2  # Expand the duplication so it resembles an insertion
+            start, end = map(int, position.split('_'))
+            repeated_unit = decipher_repeated_unit(sequence)
+            reference_start = decipher_start_of_full_reference_repeated_sequence(reference, repeated_unit, start, validator)
+            reference_end = decipher_end_of_full_reference_repeated_sequence(reference, repeated_unit, start, validator)
+            return reassemble_expanded_repeat_variant(reference, reference_start, reference_end, reference_type,
+                                                      repeated_unit, original_sequence, validator,
+                                                      converted_from_intronic=converted_from_intronic,
+                                                      alt_aln_method=alt_aln_method)
+
+        # Process deletions
+        elif "del" in seq_state_info:
+            position, sequence = seq_state_info.split('del')
+            start, end = map(int, position.split('_'))
+            repeated_unit = decipher_repeated_unit(sequence)
+            reference_start = decipher_start_of_full_reference_repeated_sequence(reference, repeated_unit, start, validator)
+            reference_end = decipher_end_of_full_reference_repeated_sequence(reference, repeated_unit, start, validator)
+            remove_units = len(sequence) // len(repeated_unit)
+            return reassemble_expanded_repeat_variant(reference, reference_start, reference_end, reference_type,
+                                                      repeated_unit, repeated_unit, validator,
+                                                      remove_units=remove_units,
+                                                      converted_from_intronic=converted_from_intronic,
+                                                      alt_aln_method=alt_aln_method)
+
+    raise VariantFormatError("Variant must be an HGVS-formatted string of type 'ins', 'del', 'dup', or '='.")
+
+
+# <LICENSE>
+# Copyright (C) 2016-2025 VariantValidator Contributors
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# </LICENSE>

--- a/VariantValidator/modules/seq_state_to_expanded_repeat.py
+++ b/VariantValidator/modules/seq_state_to_expanded_repeat.py
@@ -76,9 +76,10 @@ def decipher_repeated_unit(sequence):
             return unit
     return sequence  # Default: no recognizable repeat pattern
 
-def decipher_start_of_full_reference_repeated_sequence(reference, repeated_unit, start, validator):
+def decipher_start_of_full_reference_repeated_sequence(reference, repeated_unit, start, validator, window_size=100):
     """
-    Given a position where a repeat starts, walk backwards to find the full beginning of the repeat block.
+    Given a position where a repeat starts, fetch a larger window of sequence
+    and walk backwards in-memory to find the full beginning of the repeat block.
     """
     if not repeated_unit:
         raise RepeatedUnitError("Repeated unit must be a non-empty string.")
@@ -87,23 +88,36 @@ def decipher_start_of_full_reference_repeated_sequence(reference, repeated_unit,
 
     unit_len = len(repeated_unit)
     l_start = start - 1  # convert to 0-based
-    current_chunk = validator.sf.fetch_seq(reference, start_i=l_start, end_i=l_start + unit_len)
+
+    # Determine how far back we can fetch
+    fetch_start = max(0, l_start - window_size)
+    fetch_end = l_start + unit_len
+
+    # Fetch once
+    seq_window = validator.sf.fetch_seq(reference, start_i=fetch_start, end_i=fetch_end)
+
+    # Position of the unit in the fetched window
+    local_pos = l_start - fetch_start
+    current_chunk = seq_window[local_pos:local_pos + unit_len]
 
     if current_chunk != repeated_unit:
         return None  # Repeat does not match expected unit
 
-    while l_start - unit_len >= 0:
-        prev_chunk = validator.sf.fetch_seq(reference, start_i=l_start - unit_len, end_i=l_start)
+    # Walk backwards within the in-memory window
+    while local_pos - unit_len >= 0:
+        prev_chunk = seq_window[local_pos - unit_len:local_pos]
         if prev_chunk != repeated_unit:
             break
-        l_start -= unit_len
+        local_pos -= unit_len
 
-    return l_start + 1  # convert back to 1-based
+    # Convert back to reference coordinate (1-based)
+    return fetch_start + local_pos + 1
 
-def decipher_end_of_full_reference_repeated_sequence(reference, repeated_unit, start, validator):
+
+def decipher_end_of_full_reference_repeated_sequence(reference, repeated_unit, start, validator, window_size=100):
     """
     Walk forward from a given repeat position to find the full extent of the repeated block.
-    Tries two possible offsets to ensure frame alignment.
+    Fetch a larger window once to avoid multiple fetch_seq calls.
     """
     if not repeated_unit:
         raise RepeatedUnitError("Repeated unit must be a non-empty string.")
@@ -111,34 +125,32 @@ def decipher_end_of_full_reference_repeated_sequence(reference, repeated_unit, s
         raise StartPositionError("Start position must be a positive integer.")
 
     unit_len = len(repeated_unit)
-    start_0_try1 = start - 1 - unit_len  # one repeat length before start
-    start_0_try2 = start - 1             # direct match at start
 
-    for start_0 in [start_0_try1, start_0_try2]:
+    # Try two offsets for frame alignment
+    for start_0 in [start - 1 - unit_len, start - 1]:
         if start_0 < 0:
             continue
 
+        # Fetch a single forward window
+        fetch_end = start_0 + window_size
         try:
-            chunk = validator.sf.fetch_seq(reference, start_i=start_0, end_i=start_0 + unit_len)
+            seq_window = validator.sf.fetch_seq(reference, start_i=start_0, end_i=fetch_end)
         except Exception:
             continue
 
-        if chunk != repeated_unit:
+        # Check if the repeated unit matches at this start
+        local_pos = 0
+        if seq_window[local_pos:local_pos + unit_len] != repeated_unit:
             continue
 
-        pos = start_0
-        while True:
-            next_start = pos + unit_len
-            next_end = next_start + unit_len
-            try:
-                next_chunk = validator.sf.fetch_seq(reference, start_i=next_start, end_i=next_end)
-            except Exception:
-                break
+        # Walk forward in-memory
+        while local_pos + unit_len <= len(seq_window) - unit_len:
+            next_chunk = seq_window[local_pos + unit_len:local_pos + 2 * unit_len]
             if next_chunk != repeated_unit:
                 break
-            pos += unit_len
+            local_pos += unit_len
 
-        return pos + unit_len  # return 1-based end position
+        return start_0 + local_pos + unit_len  # convert to 1-based end position
 
     return None
 

--- a/VariantValidator/modules/variant.py
+++ b/VariantValidator/modules/variant.py
@@ -9,7 +9,7 @@ class Variant(object):
     """
 
     def __init__(self, original, quibble=None, warnings=None, write=True, primary_assembly=False, order=False,
-                 selected_assembly=False, reformat_output=False):
+                 selected_assembly=False, reformat_output=False, expanded_repeat=None):
         self.original = original
         if quibble is None:
             self.quibble = original
@@ -49,7 +49,7 @@ class Variant(object):
         self.timing = {}
         self.refsource = None
         self.reftype = None
-        self.expanded_repeat = None
+        self.expanded_repeat = expanded_repeat
 
         # Set reformat options
         self.reformat_output = reformat_output

--- a/VariantValidator/modules/vvMixinCore.py
+++ b/VariantValidator/modules/vvMixinCore.py
@@ -1415,11 +1415,10 @@ class Mixin(vvMixinConverters.Mixin):
                     # If the ER came from a gene description, set the HGVS transcript variant
                     if ex_rep_start in ["NG_", "LRG"]:
                         try:
-                            variant.hgvs_transcript_variant = (
-                                convert_seq_state_to_expanded_repeat(
+                            variant.hgvs_transcript_variant = convert_seq_state_to_expanded_repeat(
                                     variant.hgvs_transcript_variant, self,
                                     known_repeat_unit=variant.expanded_repeat["repeat_sequence"],
-                                    genomic_reference=ex_rep_var.ac))
+                                    genomic_reference=ex_rep_var.ac)
                         except Exception:
                             pass
                     elif ex_rep_start == 'NC_':
@@ -1497,7 +1496,8 @@ class Mixin(vvMixinConverters.Mixin):
                             if variant.hgvs_lrg_variant:
                                 variant.hgvs_lrg_variant = (
                                     f"{variant.hgvs_lrg_variant.split(':g.')[0]}:g." +
-                                    str(variant.hgvs_refseqgene_variant).split(':g.')[1])
+                                    variant.hgvs_refseqgene_variant.posedit.format(
+                                        {'max_ref_length': 0}))
                         except Exception:
                             pass
                         # LRG transcript data can be, but may not be, the same as the main mapped tx
@@ -1506,12 +1506,10 @@ class Mixin(vvMixinConverters.Mixin):
                         if variant.hgvs_lrg_transcript_variant and \
                                 variant.hgvs_lrg_transcript_variant.split(':c.')[1] ==\
                                 starting_tx_posedit and variant.hgvs_transcript_variant:
-                            if isinstance(variant.hgvs_transcript_variant, str):
-                                posedit = variant.hgvs_transcript_variant.split(':c.')[1]
-                            else:
-                                posedit = str(variant.hgvs_transcript_variant.posedit)
-                            variant.hgvs_lrg_transcript_variant =\
-                                f"{variant.hgvs_lrg_transcript_variant.split(':c.')[0]}:c.{posedit}"
+                            variant.hgvs_lrg_transcript_variant = \
+                                f"{variant.hgvs_lrg_transcript_variant.split(':c.')[0]}:c."\
+                                + variant.hgvs_transcript_variant.posedit.format(
+                                    {'max_ref_length': 0})
 
                 # Some variant objects must be strings for back-compatibility with old output
                 if variant.hgvs_transcript_variant:

--- a/VariantValidator/modules/vvMixinCore.py
+++ b/VariantValidator/modules/vvMixinCore.py
@@ -1419,6 +1419,9 @@ class Mixin(vvMixinConverters.Mixin):
                 for loc in variant.alt_genomic_loci:
                     for gen in loc.keys():
                         loc[gen][hgd] = loc[gen][hgd].format({'max_ref_length': 0})
+                if variant.expanded_repeat is not None:
+                    variant.expanded_repeat["variant"] = \
+                        variant.expanded_repeat["variant"].format({'max_ref_length': 0})
 
                 # Add expanded repeat information
                 logger.info(f"expanded repeat is {variant.expanded_repeat}")

--- a/VariantValidator/modules/vvMixinCore.py
+++ b/VariantValidator/modules/vvMixinCore.py
@@ -1436,14 +1436,39 @@ class Mixin(vvMixinConverters.Mixin):
                         if self.primary_assembly == "GRCh37":
                             variant.primary_assembly_loci["hg19"
                             ]["hgvs_genomic_description"] = variant.expanded_repeat["variant"]
+                            try:
+                                variant.primary_assembly_loci["grch38"
+                                ]["hgvs_genomic_description"] = (
+                                    seq_state_to_expanded_repeat.convert_seq_state_to_expanded_repeat(
+                                        str(variant.primary_assembly_loci["grch38"
+                                            ]["hgvs_genomic_description"]), self,
+                                        known_repeat_unit=variant.expanded_repeat["repeat_sequence"]))
+                            except Exception:
+                                pass
+                            variant.primary_assembly_loci["hg38"]["hgvs_genomic_description"] = (
+                                variant.primary_assembly_loci["grch38"
+                                ]["hgvs_genomic_description"])
                         else:
                             variant.primary_assembly_loci["hg38"
                             ]["hgvs_genomic_description"] = variant.expanded_repeat["variant"]
+                            try:
+                                variant.primary_assembly_loci["grch37"
+                                ]["hgvs_genomic_description"] = (
+                                    seq_state_to_expanded_repeat.convert_seq_state_to_expanded_repeat(
+                                        str(variant.primary_assembly_loci["grch37"
+                                            ]["hgvs_genomic_description"]), self,
+                                        known_repeat_unit=variant.expanded_repeat["repeat_sequence"]))
+                                variant.primary_assembly_loci["hg19"]["hgvs_genomic_description"] = (
+                                    variant.primary_assembly_loci["grch37"
+                                    ]["hgvs_genomic_description"])
+                            except Exception:
+                                pass
                         try:
                             variant.hgvs_transcript_variant = (
                                 seq_state_to_expanded_repeat.convert_seq_state_to_expanded_repeat(str(
                                     variant.hgvs_transcript_variant), self,
-                                    genomic_reference=variant.expanded_repeat["variant"].split(":")[0]))
+                                    genomic_reference=variant.expanded_repeat["variant"].split(":")[0],
+                                known_repeat_unit=variant.expanded_repeat["repeat_sequence"]))
                         except Exception:
                             pass
 
@@ -1455,7 +1480,8 @@ class Mixin(vvMixinConverters.Mixin):
                             ]["hgvs_genomic_description"] = (
                                 seq_state_to_expanded_repeat.convert_seq_state_to_expanded_repeat(str(
                                     variant.primary_assembly_loci[self.primary_assembly.lower()
-                                    ]["hgvs_genomic_description"]), self))
+                                    ]["hgvs_genomic_description"]), self,
+                                    known_repeat_unit=variant.expanded_repeat["repeat_sequence"]))
                             if self.primary_assembly == "GRCh37":
                                 variant.primary_assembly_loci["hg19"
                                 ]["hgvs_genomic_description"] = (
@@ -1465,7 +1491,8 @@ class Mixin(vvMixinConverters.Mixin):
                                 ]["hgvs_genomic_description"] = (
                                     seq_state_to_expanded_repeat.convert_seq_state_to_expanded_repeat(
                                         str(variant.primary_assembly_loci["grch38"
-                                ]["hgvs_genomic_description"]), self))
+                                ]["hgvs_genomic_description"]), self,
+                                        known_repeat_unit=variant.expanded_repeat["repeat_sequence"]))
                                 variant.primary_assembly_loci["hg38"]["hgvs_genomic_description"] = (
                                     variant.primary_assembly_loci["grch38"
                                     ]["hgvs_genomic_description"])
@@ -1478,7 +1505,8 @@ class Mixin(vvMixinConverters.Mixin):
                                 ]["hgvs_genomic_description"] = (
                                     seq_state_to_expanded_repeat.convert_seq_state_to_expanded_repeat(
                                         str(variant.primary_assembly_loci["grch37"
-                                ]["hgvs_genomic_description"]), self))
+                                ]["hgvs_genomic_description"]), self,
+                                        known_repeat_unit=variant.expanded_repeat["repeat_sequence"]))
                                 variant.primary_assembly_loci["hg19"]["hgvs_genomic_description"] = (
                                     variant.primary_assembly_loci["grch37"
                                     ]["hgvs_genomic_description"])
@@ -1490,7 +1518,8 @@ class Mixin(vvMixinConverters.Mixin):
                             try:
                                 variant.hgvs_refseqgene_variant = (
                                 seq_state_to_expanded_repeat.convert_seq_state_to_expanded_repeat(
-                                    str(variant.hgvs_refseqgene_variant), self))
+                                    str(variant.hgvs_refseqgene_variant), self,
+                                known_repeat_unit=variant.expanded_repeat["repeat_sequence"]))
                             except Exception:
                                 pass
                         if "LRG_" in variant.hgvs_lrg_variant:

--- a/VariantValidator/modules/vvMixinCore.py
+++ b/VariantValidator/modules/vvMixinCore.py
@@ -1426,9 +1426,9 @@ class Mixin(vvMixinConverters.Mixin):
                                 seq_state_to_expanded_repeat.convert_seq_state_to_expanded_repeat(str(
                                     variant.hgvs_transcript_variant), self,
                                     genomic_reference=variant.expanded_repeat["variant"].split(":")[0]))
-                        except Exception as e:
-                            variant.warnings.append(
-                                f"Failed to convert HGVS transcript variant to expanded repeat: {e}")
+                        except Exception:
+                            pass
+
 
                     if "NC_" in variant.expanded_repeat["variant"]:
                         variant.primary_assembly_loci[self.primary_assembly.lower()
@@ -1444,9 +1444,8 @@ class Mixin(vvMixinConverters.Mixin):
                                 seq_state_to_expanded_repeat.convert_seq_state_to_expanded_repeat(str(
                                     variant.hgvs_transcript_variant), self,
                                     genomic_reference=variant.expanded_repeat["variant"].split(":")[0]))
-                        except Exception as e:
-                            variant.warnings.append(
-                                f"Failed to convert HGVS transcript variant to expanded repeat: {e}")
+                        except Exception:
+                            pass
 
                     elif ("NM_" in variant.expanded_repeat["variant"] or "NR_" in variant.expanded_repeat["variant"]
                           or "ENST" in variant.expanded_repeat["variant"]):
@@ -1483,15 +1482,17 @@ class Mixin(vvMixinConverters.Mixin):
                                 variant.primary_assembly_loci["hg19"]["hgvs_genomic_description"] = (
                                     variant.primary_assembly_loci["grch37"
                                     ]["hgvs_genomic_description"])
-                        except Exception as e:
-                            variant.warnings.append(
-                                f"Failed to convert HGVS genomic variants to expanded repeat: {e}")
+                        except Exception:
+                            pass
 
                     if "NG_" in variant.hgvs_refseqgene_variant:
                         if not "NG_" in variant.expanded_repeat["variant"]:
-                            variant.hgvs_refseqgene_variant = (
+                            try:
+                                variant.hgvs_refseqgene_variant = (
                                 seq_state_to_expanded_repeat.convert_seq_state_to_expanded_repeat(
                                     str(variant.hgvs_refseqgene_variant), self))
+                            except Exception:
+                                pass
                         if "LRG_" in variant.hgvs_lrg_variant:
                             variant.hgvs_lrg_variant = (f"{variant.hgvs_lrg_variant.split(':g.')[0]}"
                                                         f":g.{variant.hgvs_refseqgene_variant.split(':g.')[1]}")

--- a/VariantValidator/modules/vvMixinInit.py
+++ b/VariantValidator/modules/vvMixinInit.py
@@ -18,7 +18,6 @@ from vvhgvs.edit import AARefAlt, AAExt, Dup
 from Bio.Seq import Seq
 
 import re
-import copy
 from .vvDatabase import Database
 from . import utils
 from VariantValidator.settings import CONFIG_DIR
@@ -197,6 +196,12 @@ class Mixin:
                                                        shuffle_direction=5,
                                                        alt_aln_method=self.alt_aln_method
                                                        )
+
+        self.hn = vvhgvs.normalizer.Normalizer(self.hdp,
+                                               cross_boundaries=False,
+                                               shuffle_direction=3,
+                                               alt_aln_method=self.alt_aln_method
+                                               )
 
         self.merge_normalizer = vvhgvs.normalizer.Normalizer(
            self.hdp,

--- a/tests/test_expanded_repeats.py
+++ b/tests/test_expanded_repeats.py
@@ -12,6 +12,7 @@ Additional functionality to add:
 import unittest
 from unittest import TestCase
 from VariantValidator.modules import expanded_repeats
+from VariantValidator.modules.expanded_repeats import RepeatSyntaxError
 from VariantValidator import Validator
 vv = Validator()
 vv.alt_aln_method = "splign"
@@ -39,12 +40,12 @@ class TestExpandedRepeats(unittest.TestCase):
         my_variant.reformat_reference()
         my_variant.check_genomic_or_coding()
         formatted = my_variant.reformat(vv)
-        assert formatted == "NG_012232.1:g.3_6T[20]"
+        assert str(formatted) == "NG_012232.1:g.3_6T[20]"
         assert my_variant.variant_str == "NG_012232.1:g.4T[20]"
         # checks correct transcript ref
         assert my_variant.reference == "NG_012232.1"
         # checks correct position
-        assert my_variant.variant_position == "3_6"
+        assert str(my_variant.variant_position) == "3_6"
         # checks repeat seq
         assert my_variant.repeat_sequence == "T"
         # checks correct suffix
@@ -67,12 +68,12 @@ class TestExpandedRepeats(unittest.TestCase):
         my_variant.reformat_reference()
         my_variant.check_genomic_or_coding()
         formatted = my_variant.reformat(vv)
-        assert formatted == "ENST00000263121.12:c.*62_*67TCT[2]"
+        assert str(formatted) == "ENST00000263121.12:c.*62_*67TCT[2]"
         assert my_variant.variant_str == "ENST00000263121.12:c.*62_*67TCT[2]"
         assert my_variant.prefix == "c"
         assert my_variant.reference == "ENST00000263121.12"
         # checks correct ref name
-        assert my_variant.variant_position == "*62_*67"
+        assert str(my_variant.variant_position) == "*62_*67"
         # checks correct position
         assert my_variant.repeat_sequence == "TCT"
         # checks repeat seq
@@ -87,16 +88,16 @@ class TestExpandedRepeats(unittest.TestCase):
         """
         variant_str = "NM_000492.4:c.1210-34TG[11]"
         my_variant = expanded_repeats.TandemRepeats.parse_repeat_variant(variant_str, "GRCh38", "all", vv)
-        assert my_variant.variant_position == "1210-34"
+        assert str(my_variant.variant_position) == "1210-34"
         my_variant.reformat_reference()
         my_variant.check_genomic_or_coding()
         formatted = my_variant.reformat(vv)
-        assert formatted == "NM_000492.4:c.1210-34_1210-13TG[11]"
+        assert str(formatted) == "NM_000492.4:c.1210-34_1210-13TG[11]"
         assert my_variant.variant_str == "NM_000492.4:c.1210-34TG[11]"
         assert my_variant.prefix == "c"
         assert my_variant.reference == "NM_000492.4"
         # checks correct ref name
-        assert my_variant.variant_position == "1210-34_1210-13"
+        assert str(my_variant.variant_position) == "1210-34_1210-13"
         # checks correct position
         assert my_variant.repeat_sequence == "TG"
         # checks repeat seq
@@ -113,7 +114,8 @@ class TestExpandedRepeats(unittest.TestCase):
         my_variant = expanded_repeats.TandemRepeats.parse_repeat_variant(
                                     variant_str,  "GRCh37", "all", vv)
         # Includes cds offset
-        self.assertEqual(expanded_repeats.TandemRepeats.get_range_from_single_or_start_pos(my_variant, vv), "1289_1297")
+        seq_range = expanded_repeats.TandemRepeats.get_range_from_single_or_start_pos(my_variant, vv)
+        self.assertEqual(str(seq_range), "1289_1297")
 
     def test_empty_string(self):
         """
@@ -124,6 +126,145 @@ class TestExpandedRepeats(unittest.TestCase):
                                     variant_str, "GRCh37", "all", vv)
         assert my_variant == False
 
+    def test_convert_tandem_fallback(self):
+        """
+        Test that fallback happens when input variant is a text hgvs variant not VV variant object
+        """
+        variant_str = "NM_003073.5:c.1085AGA[2]"
+        my_variant_data = expanded_repeats.convert_tandem(variant_str, vv, 'GRCh37', 'all')
+        self.assertEqual(str(my_variant_data["position"]), "1085_1093")
+        self.assertEqual(str(my_variant_data["variant"]), "NM_003073.5:c.1085_1093AGA[2]")
+        self.assertEqual(my_variant_data["copy_number"],'2')
+        self.assertEqual(my_variant_data["repeat_sequence"],"AGA")
+        self.assertEqual(my_variant_data["reference"],"NM_003073.5")
+        self.assertEqual(my_variant_data["prefix"],"c")
+        self.assertEqual(my_variant_data["reference_sequence_bases"],"AGAAGAAGA")
+
+    def test_fail_tandem_unmatched_bracket(self):
+        variant_str = "NM_003073.5:c.1085AGA[2"
+        with self.assertRaises(RepeatSyntaxError) as catch:
+            expanded_repeats.convert_tandem(variant_str, vv, 'GRCh37', 'all')
+        self.assertTrue("variant in question is missing a matched bracket pair" in \
+                str(catch.exception))
+
+    def test_fail_tandem_no_repeat(self):
+        variant_str = "NM_003073.5:c.1085[2]"
+        with self.assertRaises(RepeatSyntaxError) as catch:
+            expanded_repeats.convert_tandem(variant_str, vv, 'GRCh37', 'all')
+        self.assertTrue(
+                "Ensure that the repeated sequence is included" in \
+                str(catch.exception))
+
+    def test_fail_tandem_bad_repeat_seq(self):
+        variant_str = "NM_003073.5:c.1085CXXX[2]"
+        with self.assertRaises(RepeatSyntaxError) as catch:
+            expanded_repeats.convert_tandem(variant_str, vv, 'GRCh37', 'all')
+        self.assertTrue(
+            "Please ensure the repeated sequence includes only Aa, Cc, Tt, Gg, Uu" in \
+            str(catch.exception))
+
+    def test_fail_tandem_bad_repeat_length(self):
+        variant_str = "NM_003073.5:c.1085_1092AGA[2]"
+        my_variant = expanded_repeats.TandemRepeats.parse_repeat_variant(
+                variant_str,  "GRCh37", "all", vv)
+
+        with self.assertRaises(RepeatSyntaxError) as catch:
+            my_variant.check_positions_given(vv)
+        self.assertTrue(
+            "is not a multiple of the length of the provided repeat sequence" in \
+            str(catch.exception))
+
+    def test_fail_tandem_ref_nomatch(self):
+        # need a span to trigger this test
+        # also needs a test for no alt at test time [0] code path
+        variant_str = "NM_000492.4:c.1210-35_1210-12TG[11]"
+        my_variant = expanded_repeats.TandemRepeats.parse_repeat_variant(
+                variant_str,  "GRCh37", "all", vv)
+        my_variant.get_valid_n_or_g_range_from_input_pos(vv)
+        with self.assertRaises(RepeatSyntaxError) as catch:
+            my_variant.check_positions_given(vv)
+        self.assertTrue(
+            "The repeat sequence does not match the reference sequence " in \
+            str(catch.exception))
+        variant_str = "NM_003073.5:c.1085_1093AGA[0]"
+        my_variant = expanded_repeats.TandemRepeats.parse_repeat_variant(
+                variant_str,  "GRCh37", "all", vv)
+        my_variant.get_valid_n_or_g_range_from_input_pos(vv)
+        my_variant.check_positions_given(vv)
+
+    def test_fail_reformat_if_extra_after_the_bracket(self):
+        # self.after_the_bracket needs to be true when bad variant passed
+        variant_str = "NG_012232.1:g.4T[20]wrong"
+        my_variant = expanded_repeats.TandemRepeats.parse_repeat_variant(
+                variant_str,  "GRCh37", "all", vv)
+        with self.assertRaises(RepeatSyntaxError) as catch:
+            formatted = my_variant.reformat(vv)
+        self.assertTrue(
+            "No information should be included after the number of repeat units." in \
+            str(catch.exception))
+
+    def test_fail_reformat_if_bad_repeat_characters(self):
+        variant_str = "NG_012232.1:g.4CC[20]"
+        my_variant = expanded_repeats.TandemRepeats.parse_repeat_variant(
+                variant_str,  "GRCh37", "all", vv)
+        with self.assertRaises(RepeatSyntaxError) as catch:
+            my_variant.repeat_sequence = 'EE'
+            formatted = my_variant.reformat(vv)
+        self.assertTrue(
+            "Please ensure the repeated sequence includes only Aa, Cc, Tt, Gg, Uu" in \
+            str(catch.exception))
+
+    def test_fail_reformat_if_not_copy_number_is_decimal(self):
+        #switch to is int?
+        variant_str = "NG_012232.1:g.4T[aaa]"
+        my_variant = expanded_repeats.TandemRepeats.parse_repeat_variant(
+                variant_str,  "GRCh37", "all", vv)
+        with self.assertRaises(RepeatSyntaxError) as catch:
+            formatted = my_variant.reformat(vv)
+        self.assertTrue(
+            "The number of repeat units included between square brackets must be numeric" in \
+            str(catch.exception))
+
+
+    #def test_pass_tandem_ref_nomatch_no_length(self):
+    #    # No length for genomic match, and fail caught, should only happen for broken input
+    #    # which should be caught already, or coordinates beyond the end of the seq.
+    #    # This could not trigger and was removed, we may want to add a ^ / $ to the regex
+    #    # however, and if so would then want to re-add this test.
+    #    variant_str = "NG_012232.1:g.90000000CC[20]"
+    #    my_variant = expanded_repeats.TandemRepeats.parse_repeat_variant(
+    #            variant_str,  "GRCh37", "all", vv)
+    #    my_variant.check_positions_given(vv)
+
+    def test_check_exon_boundaries_no_bounds_used(self):
+        variant_str = "NM_003073.5:c.1085AGA[2]"
+        my_variant = expanded_repeats.TandemRepeats.parse_repeat_variant(
+                variant_str, vv, 'GRCh37', 'all')
+        my_variant.check_exon_boundaries(vv)
+
+    def test_exon_c_to_n_safe_on_n(self):
+        # convert_c_to_n_coordinates should be safe to call on n/g input
+        variant_str = "NG_012232.1:g.4T[5]"
+        my_variant = expanded_repeats.TandemRepeats.parse_repeat_variant(
+                variant_str,  "GRCh37", "all", vv)
+        pos = str(my_variant.variant_position)
+        my_variant.convert_c_to_n_coordinates()
+        assert pos == str(my_variant.variant_position)
+
+    def test_bad_coppy_number_after_genomic_map(self):
+        # test in get_range_from_single_or_start_pos
+        # during remap of BaseOffsetInterval type pos with at least one .offset
+        # i.e. intronic n/c
+        # when number of regex matches within range of genomic span != expected
+        variant_str = "NM_000492.4:c.1210-34_1210-11TG[11]"
+        variant = expanded_repeats.TandemRepeats.parse_repeat_variant(
+            variant_str,'GRCh37', 'all',vv)
+
+        with self.assertRaises(RepeatSyntaxError) as catch:
+            variant.reformat(vv)
+        self.assertTrue(
+            "The repeat sequence does not match the expected copy number at position" in\
+            str(catch.exception))
 
 class TestCVariantsExpanded(TestCase):
 
@@ -145,6 +286,14 @@ class TestCVariantsExpanded(TestCase):
         assert ("ExonBoundaryError: Position 13-14 does not correspond with an exon boundary for transcript "
                 "NM_004006.2") in results["validation_warning_1"]["validation_warnings"]
 
+    def test_exon_boundary_single_position_plus(self):
+        variant = 'NM_004006.2:c.13+14AC[7]'
+        results = self.vv.validate(variant, 'GRCh37', 'all').format_as_dict(test=True)
+        print(results)
+        assert ("ExonBoundaryError: Position 13+14 does not correspond with an exon boundary for transcript "
+                "NM_004006.2") in results["validation_warning_1"]["validation_warnings"]
+
+
     def test_exon_boundary_range(self):
         variant = 'NM_004006.2:c.12_13-14AC[7]'
         results = self.vv.validate(variant, 'GRCh37', 'all').format_as_dict(test=True)
@@ -162,7 +311,6 @@ class TestCVariantsExpanded(TestCase):
             "validation_warnings"] ==  [
             "ExpandedRepeatError: The coordinates for the repeat region are stated incorrectly in the submitted description NM_000492.4:c.1210-34TG[11]. The corrected description is NM_000492.4:c.1210-34_1210-13TG[11]",
             "ExpandedRepeatWarning: NM_000492.4:c.1210-34_1210-13TG[11] should only be used as an annotation for the core HGVS descriptions provided",
-            "NM_000492.4:c.1210-34_1210-13delinsTGTGTGTGTGTGTGTGTGTGTG automapped to NM_000492.4:c.1210-34_1210-13="
         ]
 
     def test_intronic_range(self):
@@ -175,7 +323,6 @@ class TestCVariantsExpanded(TestCase):
             "validation_warnings"] == [
             "ExpandedRepeatWarning: NM_000492.4:c.1210-34_1210-13TG[11] should only be used as an annotation for the "
             "core HGVS descriptions provided",
-            "NM_000492.4:c.1210-34_1210-13delinsTGTGTGTGTGTGTGTGTGTGTG automapped to NM_000492.4:c.1210-34_1210-13="
         ]
 
     def test_incorrect_intronic_range(self):
@@ -286,7 +433,6 @@ class TestCVariantsExpanded(TestCase):
             "validation_warnings"] == [
             "ExpandedRepeatWarning: NM_000088.3:c.589-1_590G[3] should only be used as an annotation for the "
             "core HGVS descriptions provided",
-            "NM_000088.3:c.589-1_590delinsGGG automapped to NM_000088.3:c.589-1_590=",
             "TranscriptVersionWarning: A more recent version of the selected reference sequence NM_000088.3 "
             "is available for genome build GRCh37 (NM_000088.4)"
         ]
@@ -301,7 +447,6 @@ class TestCVariantsExpanded(TestCase):
                    "validation_warnings"] == [
             "ExpandedRepeatError: The coordinates for the repeat region are stated incorrectly in the submitted description NM_000088.3:c.589-1G[3]. The corrected description is NM_000088.3:c.589-1_590G[3]",
             "ExpandedRepeatWarning: NM_000088.3:c.589-1_590G[3] should only be used as an annotation for the core HGVS descriptions provided",
-            "NM_000088.3:c.589-1_590delinsGGG automapped to NM_000088.3:c.589-1_590=",
             "TranscriptVersionWarning: A more recent version of the selected reference sequence NM_000088.3 is available for genome build GRCh37 (NM_000088.4)"
         ]
 
@@ -315,7 +460,6 @@ class TestCVariantsExpanded(TestCase):
                    "validation_warnings"] == [
             "ExpandedRepeatError: The coordinates for the repeat region are stated incorrectly in the submitted description NM_000088.3:c.589-18T[5]. The corrected description is NM_000088.3:c.589-18_589-14T[5]",
             "ExpandedRepeatWarning: NM_000088.3:c.589-18_589-14T[5] should only be used as an annotation for the core HGVS descriptions provided",
-            "NM_000088.3:c.589-18_589-14delinsTTTTT automapped to NM_000088.3:c.589-18_589-14=",
             "TranscriptVersionWarning: A more recent version of the selected reference sequence NM_000088.3 is available for genome build GRCh37 (NM_000088.4)"
         ]
 
@@ -418,7 +562,6 @@ class TestTranscriptVariantsExpandedNvsC(TestCase):
             "validation_warnings"] ==  [
             "ExpandedRepeatError: The coordinates for the repeat region are stated incorrectly in the submitted description NM_022167.4:c.135+1G[2]. The corrected description is NM_022167.4:c.135_135+1G[2]",
             "ExpandedRepeatWarning: NM_022167.4:c.135_135+1G[2] should only be used as an annotation for the core HGVS descriptions provided",
-            "NM_022167.4:c.135_135+1delinsGG automapped to NM_022167.4:c.135_135+1="
         ]
 
     def test_intronic_single_position_n(self):
@@ -431,7 +574,6 @@ class TestTranscriptVariantsExpandedNvsC(TestCase):
             "validation_warnings"] == [
             "ExpandedRepeatError: The coordinates for the repeat region are stated incorrectly in the submitted description NR_110010.2:n.150+1G[2]. The corrected description is NR_110010.2:n.150_150+1G[2]",
             "ExpandedRepeatWarning: NR_110010.2:n.150_150+1G[2] should only be used as an annotation for the core HGVS descriptions provided",
-            "NR_110010.2:n.150_150+1delinsGG automapped to NR_110010.2:n.150_150+1="
         ]
 
     def test_intronic_range_c(self):
@@ -444,7 +586,6 @@ class TestTranscriptVariantsExpandedNvsC(TestCase):
             "validation_warnings"] == [
             "ExpandedRepeatWarning: NM_022167.4:c.135+6_135+7C[2] should only be used as an "
             "annotation for the core HGVS descriptions provided",
-            "NM_022167.4:c.135+6_135+7delinsCC automapped to NM_022167.4:c.135+6_135+7="
         ]
 
     def test_intronic_range_n(self):
@@ -457,7 +598,6 @@ class TestTranscriptVariantsExpandedNvsC(TestCase):
             "validation_warnings"] == [
             "ExpandedRepeatWarning: NR_110010.2:n.150+6_150+7C[2] should only be used as an "
             "annotation for the core HGVS descriptions provided",
-            "NR_110010.2:n.150+6_150+7delinsCC automapped to NR_110010.2:n.150+6_150+7="
         ]
 
     def test_incorrect_intronic_range_c(self):
@@ -618,7 +758,6 @@ class TestTranscriptVariantsExpandedNvsC(TestCase):
         assert results["NM_001350922.2:c.240+14_240+21TGGG[2]"]["validation_warnings"] == [
             "ExpandedRepeatWarning: NM_001350922.2:c.240+14_240+21TGGG[2] should only be used as "
             "an annotation for the core HGVS descriptions provided",
-            "NM_001350922.2:c.240+14_240+21delinsTGGGTGGG automapped to NM_001350922.2:c.240+14_240+21=",
         ]
 
     def test_antisense_intron_range_n(self):
@@ -630,7 +769,6 @@ class TestTranscriptVariantsExpandedNvsC(TestCase):
         assert results["NR_146939.2:n.453+14_453+21TGGG[2]"]["validation_warnings"] == [
             "ExpandedRepeatWarning: NR_146939.2:n.453+14_453+21TGGG[2] should only be used as an "
             "annotation for the core HGVS descriptions provided",
-            "NR_146939.2:n.453+14_453+21delinsTGGGTGGG automapped to NR_146939.2:n.453+14_453+21=",
         ]
 
     def test_antisense_intron_single_pos_c(self):
@@ -642,7 +780,6 @@ class TestTranscriptVariantsExpandedNvsC(TestCase):
         assert results["NM_001350922.2:c.240+14_240+21TGGG[2]"]["validation_warnings"] == [
             "ExpandedRepeatError: The coordinates for the repeat region are stated incorrectly in the submitted description NM_001350922.2:c.240+14TGGG[2]. The corrected description is NM_001350922.2:c.240+14_240+21TGGG[2]",
             "ExpandedRepeatWarning: NM_001350922.2:c.240+14_240+21TGGG[2] should only be used as an annotation for the core HGVS descriptions provided",
-            "NM_001350922.2:c.240+14_240+21delinsTGGGTGGG automapped to NM_001350922.2:c.240+14_240+21="
         ]
 
     def test_antisense_intron_single_pos_n(self):
@@ -654,7 +791,6 @@ class TestTranscriptVariantsExpandedNvsC(TestCase):
         assert results["NR_146939.2:n.453+14_453+21TGGG[2]"]["validation_warnings"] == [
             "ExpandedRepeatError: The coordinates for the repeat region are stated incorrectly in the submitted description NR_146939.2:n.453+14TGGG[2]. The corrected description is NR_146939.2:n.453+14_453+21TGGG[2]",
             "ExpandedRepeatWarning: NR_146939.2:n.453+14_453+21TGGG[2] should only be used as an annotation for the core HGVS descriptions provided",
-            "NR_146939.2:n.453+14_453+21delinsTGGGTGGG automapped to NR_146939.2:n.453+14_453+21="
         ]
 
     def test_antisense_intron_single_pos_2_c(self):
@@ -666,7 +802,6 @@ class TestTranscriptVariantsExpandedNvsC(TestCase):
         assert results["NM_001350922.2:c.241-121_241-118TC[2]"]["validation_warnings"] ==  [
             "ExpandedRepeatError: The coordinates for the repeat region are stated incorrectly in the submitted description NM_001350922.2:c.241-119TC[2]. The corrected description is NM_001350922.2:c.241-121_241-118TC[2]",
             "ExpandedRepeatWarning: NM_001350922.2:c.241-121_241-118TC[2] should only be used as an annotation for the core HGVS descriptions provided",
-            "NM_001350922.2:c.241-121_241-118delinsTCTC automapped to NM_001350922.2:c.241-121_241-118="
         ]
 
     def test_antisense_intron_single_pos_2_n(self):
@@ -678,7 +813,6 @@ class TestTranscriptVariantsExpandedNvsC(TestCase):
         assert results["NR_146939.2:n.454-121_454-118TC[2]"]["validation_warnings"] == [
             "ExpandedRepeatError: The coordinates for the repeat region are stated incorrectly in the submitted description NR_146939.2:n.454-119TC[2]. The corrected description is NR_146939.2:n.454-121_454-118TC[2]",
             "ExpandedRepeatWarning: NR_146939.2:n.454-121_454-118TC[2] should only be used as an annotation for the core HGVS descriptions provided",
-            "NR_146939.2:n.454-121_454-118delinsTCTC automapped to NR_146939.2:n.454-121_454-118="
         ]
 
     def test_antisense_intron_single_pos_seq_inverted_c(self):
@@ -722,12 +856,12 @@ class TestExpandedRepeatGenomic(TestCase):
         my_variant.reformat_reference()
         my_variant.check_genomic_or_coding()
         formatted = my_variant.reformat(vv)
-        assert formatted == "NC_000023.10:g.33362721_33362724A[20]"
+        assert str(formatted) == "NC_000023.10:g.33362721_33362724A[20]"
         assert my_variant.variant_str == "NC_000023.10:g.33362721A[20]"
         # check, in order ref ID, variant_pos, seq, copy number
         # and post-var content (should be none)
         assert my_variant.reference == "NC_000023.10"
-        assert my_variant.variant_position == "33362721_33362724"
+        assert str(my_variant.variant_position) == "33362721_33362724"
         assert my_variant.repeat_sequence == "A"
         assert my_variant.copy_number == "20"
         assert my_variant.after_the_bracket == ""
@@ -925,12 +1059,12 @@ class TestExpandedRepeatRefSeqGenomic(TestCase):
         my_variant.reformat_reference()
         my_variant.check_genomic_or_coding()
         formatted = my_variant.reformat(vv)
-        assert formatted == "NG_012232.1:g.3_6T[20]"
+        assert str(formatted) == "NG_012232.1:g.3_6T[20]"
         assert my_variant.variant_str == "NG_012232.1:g.4T[20]"
         # checks correct transcript ref
         assert my_variant.reference == "NG_012232.1"
         # checks correct position
-        assert my_variant.variant_position == "3_6"
+        assert str(my_variant.variant_position) == "3_6"
         # checks repeat seq
         assert my_variant.repeat_sequence == "T"
         # checks correct suffix
@@ -1042,7 +1176,6 @@ class TestExpandedRepeatRefSeqGenomic(TestCase):
         assert results["NM_022167.4:c.135_135+1G[2]"]["validation_warnings"] == [
             "ExpandedRepeatError: The coordinates for the repeat region are stated incorrectly in the submitted description NM_022167.4:c.135+1G[2]. The corrected description is NM_022167.4:c.135_135+1G[2]",
             "ExpandedRepeatWarning: NM_022167.4:c.135_135+1G[2] should only be used as an annotation for the core HGVS descriptions provided",
-            "NM_022167.4:c.135_135+1delinsGG automapped to NM_022167.4:c.135_135+1="
         ]
 
     def test_RSG_mapping_transcript_intron_range(self):
@@ -1064,7 +1197,6 @@ class TestExpandedRepeatRefSeqGenomic(TestCase):
         assert results["NM_022167.4:c.135_135+1G[2]"]["validation_warnings"] == [
             "ExpandedRepeatWarning: NM_022167.4:c.135_135+1G[2] should only be used as an "
             "annotation for the core HGVS descriptions provided",
-            'NM_022167.4:c.135_135+1delinsGG automapped to NM_022167.4:c.135_135+1='
         ]
 
 
@@ -1091,12 +1223,12 @@ class TestExpandedRepeaLocusReferenceGenomic(TestCase):
         my_variant.reformat_reference()
         my_variant.check_genomic_or_coding()
         formatted = my_variant.reformat(vv)
-        assert formatted == "NG_012232.1:g.3_6T[20]"
+        assert str(formatted) == "NG_012232.1:g.3_6T[20]"
         assert my_variant.variant_str == "LRG_199:g.4T[20]"
         # checks correct transcript ref
         assert my_variant.reference == "NG_012232.1"
         # checks correct position
-        assert my_variant.variant_position == "3_6"
+        assert str(my_variant.variant_position) == "3_6"
         # checks repeat seq
         assert my_variant.repeat_sequence == "T"
         # checks correct suffix
@@ -1117,12 +1249,12 @@ class TestExpandedRepeaLocusReferenceGenomic(TestCase):
         my_variant.reformat_reference()
         my_variant.check_genomic_or_coding()
         formatted = my_variant.reformat(vv)
-        assert formatted == "NM_004006.2:c.-120_-114T[7]"
+        assert str(formatted) == "NM_004006.2:c.-120_-114T[7]"
         assert my_variant.variant_str == "LRG_199t1:c.-120T[7]"
         # checks correct transcript ref
         assert my_variant.reference == "NM_004006.2"
         # checks correct position
-        assert my_variant.variant_position == "-120_-114"
+        assert str(my_variant.variant_position) == "-120_-114"
         # checks repeat seq
         assert my_variant.repeat_sequence == "T"
         # checks correct suffix
@@ -1223,7 +1355,6 @@ class TestExpandedRepeaLocusReferenceGenomic(TestCase):
         assert results["NM_004006.2:c.31+9_31+11A[3]"]["validation_warnings"] ==  [
             "ExpandedRepeatError: The coordinates for the repeat region are stated incorrectly in the submitted description LRG_199t1:c.31+9A[3]. The corrected description is NM_004006.2:c.31+9_31+11A[3]",
             "ExpandedRepeatWarning: NM_004006.2:c.31+9_31+11A[3] should only be used as an annotation for the core HGVS descriptions provided",
-            "NM_004006.2:c.31+9_31+11delinsAAA automapped to NM_004006.2:c.31+9_31+11=",
             "TranscriptVersionWarning: A more recent version of the selected reference sequence NM_004006.2 is available for genome build GRCh37 (NM_004006.3)"
         ]
 

--- a/tests/test_expanded_repeats.py
+++ b/tests/test_expanded_repeats.py
@@ -136,7 +136,7 @@ class TestCVariantsExpanded(TestCase):
         variant = 'NM_004006.2:c.-3_1A[4]'
         results = self.vv.validate(variant, 'GRCh37', 'all').format_as_dict(test=True)
         print(results)
-        assert 'NM_004006.2:c.-3_1=' in results
+        assert 'NM_004006.2:c.-3_1A[4]' in results
 
     def test_exon_boundary_single_position(self):
         variant = 'NM_004006.2:c.13-14AC[7]'
@@ -156,9 +156,9 @@ class TestCVariantsExpanded(TestCase):
         variant = 'NM_000492.4:c.1210-34TG[11]'
         results = self.vv.validate(variant, 'GRCh37', 'all').format_as_dict(test=True)
         print(results)
-        assert results["NM_000492.4:c.1210-34_1210-13="][
-            "primary_assembly_loci"]["grch37"]["hgvs_genomic_description"] == "NC_000007.13:g.117188661_117188682="
-        assert results["NM_000492.4:c.1210-34_1210-13="][
+        assert results["NM_000492.4:c.1210-34_1210-13TG[11]"][
+            "primary_assembly_loci"]["grch37"]["hgvs_genomic_description"] == "NC_000007.13:g.117188661_117188682TG[11]"
+        assert results["NM_000492.4:c.1210-34_1210-13TG[11]"][
             "validation_warnings"] ==  [
             "ExpandedRepeatError: The coordinates for the repeat region are stated incorrectly in the submitted description NM_000492.4:c.1210-34TG[11]. The corrected description is NM_000492.4:c.1210-34_1210-13TG[11]",
             "ExpandedRepeatWarning: NM_000492.4:c.1210-34_1210-13TG[11] should only be used as an annotation for the core HGVS descriptions provided",
@@ -169,9 +169,9 @@ class TestCVariantsExpanded(TestCase):
         variant = 'NM_000492.4:c.1210-34_1210-13TG[11]'
         results = self.vv.validate(variant, 'GRCh37', 'all').format_as_dict(test=True)
         print(results)
-        assert results["NM_000492.4:c.1210-34_1210-13="][
-            "primary_assembly_loci"]["grch37"]["hgvs_genomic_description"] == "NC_000007.13:g.117188661_117188682="
-        assert results["NM_000492.4:c.1210-34_1210-13="][
+        assert results["NM_000492.4:c.1210-34_1210-13TG[11]"][
+            "primary_assembly_loci"]["grch37"]["hgvs_genomic_description"] == "NC_000007.13:g.117188661_117188682TG[11]"
+        assert results["NM_000492.4:c.1210-34_1210-13TG[11]"][
             "validation_warnings"] == [
             "ExpandedRepeatWarning: NM_000492.4:c.1210-34_1210-13TG[11] should only be used as an annotation for the "
             "core HGVS descriptions provided",
@@ -192,9 +192,9 @@ class TestCVariantsExpanded(TestCase):
         variant = 'NM_003073.5:c.1085AGA[3]'
         results = self.vv.validate(variant, 'GRCh37', 'all').format_as_dict(test=True)
         print(results)
-        assert results["NM_003073.5:c.1085_1093="][
-            "primary_assembly_loci"]["grch37"]["hgvs_genomic_description"] == "NC_000022.10:g.24175857_24175865="
-        assert results["NM_003073.5:c.1085_1093="][
+        assert results["NM_003073.5:c.1085_1093AGA[3]"][
+            "primary_assembly_loci"]["grch37"]["hgvs_genomic_description"] == "NC_000022.10:g.24175857_24175865AGA[3]"
+        assert results["NM_003073.5:c.1085_1093AGA[3]"][
             "validation_warnings"] ==  [
             "ExpandedRepeatError: The coordinates for the repeat region are stated incorrectly in the submitted description NM_003073.5:c.1085AGA[3]. The corrected description is NM_003073.5:c.1085_1093AGA[3]",
             "ExpandedRepeatWarning: NM_003073.5:c.1085_1093AGA[3] should only be used as an annotation for the core HGVS descriptions provided"
@@ -204,9 +204,9 @@ class TestCVariantsExpanded(TestCase):
         variant = 'NM_003073.5:c.1085_1093AGA[3]'
         results = self.vv.validate(variant, 'GRCh37', 'all').format_as_dict(test=True)
         print(results)
-        assert results["NM_003073.5:c.1085_1093="][
-            "primary_assembly_loci"]["grch37"]["hgvs_genomic_description"] == "NC_000022.10:g.24175857_24175865="
-        assert results["NM_003073.5:c.1085_1093="][
+        assert results["NM_003073.5:c.1085_1093AGA[3]"][
+            "primary_assembly_loci"]["grch37"]["hgvs_genomic_description"] == "NC_000022.10:g.24175857_24175865AGA[3]"
+        assert results["NM_003073.5:c.1085_1093AGA[3]"][
             "validation_warnings"] == [
             "ExpandedRepeatWarning: NM_003073.5:c.1085_1093AGA[3] should only be used as an annotation for the core "
             "HGVS descriptions provided"
@@ -226,9 +226,9 @@ class TestCVariantsExpanded(TestCase):
         variant = 'NM_002024.5:c.-129CGG[10]'
         results = self.vv.validate(variant, 'GRCh37', 'all').format_as_dict(test=True)
         print(results)
-        assert results["NM_002024.5:c.-129_-100="][
-            "primary_assembly_loci"]["grch37"]["hgvs_genomic_description"] == "NC_000023.10:g.146993569_146993598="
-        assert results["NM_002024.5:c.-129_-100="][
+        assert results["NM_002024.5:c.-129_-100CGG[10]"][
+            "primary_assembly_loci"]["grch37"]["hgvs_genomic_description"] == "NC_000023.10:g.146993569_146993598CGG[10]"
+        assert results["NM_002024.5:c.-129_-100CGG[10]"][
             "validation_warnings"] == [
             "ExpandedRepeatError: The coordinates for the repeat region are stated incorrectly in the submitted description NM_002024.5:c.-129CGG[10]. The corrected description is NM_002024.5:c.-129_-100CGG[10]",
             "ExpandedRepeatWarning: NM_002024.5:c.-129_-100CGG[10] should only be used as an annotation for the core HGVS descriptions provided",
@@ -239,9 +239,9 @@ class TestCVariantsExpanded(TestCase):
         variant = 'NM_002024.5:c.-129_-100CGG[10]'
         results = self.vv.validate(variant, 'GRCh37', 'all').format_as_dict(test=True)
         print(results)
-        assert results["NM_002024.5:c.-129_-100="][
-            "primary_assembly_loci"]["grch37"]["hgvs_genomic_description"] == "NC_000023.10:g.146993569_146993598="
-        assert results["NM_002024.5:c.-129_-100="][
+        assert results["NM_002024.5:c.-129_-100CGG[10]"][
+            "primary_assembly_loci"]["grch37"]["hgvs_genomic_description"] == "NC_000023.10:g.146993569_146993598CGG[10]"
+        assert results["NM_002024.5:c.-129_-100CGG[10]"][
             "validation_warnings"] == [
             "ExpandedRepeatWarning: NM_002024.5:c.-129_-100CGG[10] should only be used as an annotation for the core "
             "HGVS descriptions provided",
@@ -269,9 +269,9 @@ class TestCVariantsExpanded(TestCase):
         variant = 'NM_002111.8:c.54GCA[21]'
         results = self.vv.validate(variant, 'GRCh37', 'all').format_as_dict(test=True)
         print(results)
-        assert results["NM_002111.8:c.54_116="]["primary_assembly_loci"]["grch37"][
-            "hgvs_genomic_description"] == "NC_000004.11:g.3076657_3076662dup"
-        assert results["NM_002111.8:c.54_116="]["validation_warnings"] ==  [
+        assert results["NM_002111.8:c.54_116GCA[21]"]["primary_assembly_loci"]["grch37"][
+            "hgvs_genomic_description"] == "NC_000004.11:g.3076606_3076662GCA[21]"
+        assert results["NM_002111.8:c.54_116GCA[21]"]["validation_warnings"] ==  [
             "ExpandedRepeatError: The coordinates for the repeat region are stated incorrectly in the submitted description NM_002111.8:c.54GCA[21]. The corrected description is NM_002111.8:c.54_116GCA[21]",
             "ExpandedRepeatWarning: NM_002111.8:c.54_116GCA[21] should only be used as an annotation for the core HGVS descriptions provided"
         ]
@@ -280,9 +280,9 @@ class TestCVariantsExpanded(TestCase):
         variant = 'NM_000088.3:c.589-1_590G[3]'
         results = self.vv.validate(variant, 'GRCh37', 'all').format_as_dict(test=True)
         print(results)
-        assert results["NM_000088.3:c.589-1_590="][
-            "primary_assembly_loci"]["grch37"]["hgvs_genomic_description"] == "NC_000017.10:g.48275362_48275364="
-        assert results["NM_000088.3:c.589-1_590="][
+        assert results["NM_000088.3:c.589-1_590G[3]"][
+            "primary_assembly_loci"]["grch37"]["hgvs_genomic_description"] == "NC_000017.10:g.48275362_48275364C[3]"
+        assert results["NM_000088.3:c.589-1_590G[3]"][
             "validation_warnings"] == [
             "ExpandedRepeatWarning: NM_000088.3:c.589-1_590G[3] should only be used as an annotation for the "
             "core HGVS descriptions provided",
@@ -295,9 +295,9 @@ class TestCVariantsExpanded(TestCase):
         variant = 'NM_000088.3:c.589-1G[3]'
         results = self.vv.validate(variant, 'GRCh37', 'all').format_as_dict(test=True)
         print(results)
-        assert results["NM_000088.3:c.589-1_590="][
-                   "primary_assembly_loci"]["grch37"]["hgvs_genomic_description"] == "NC_000017.10:g.48275362_48275364="
-        assert results["NM_000088.3:c.589-1_590="][
+        assert results["NM_000088.3:c.589-1_590G[3]"][
+                   "primary_assembly_loci"]["grch37"]["hgvs_genomic_description"] == "NC_000017.10:g.48275362_48275364C[3]"
+        assert results["NM_000088.3:c.589-1_590G[3]"][
                    "validation_warnings"] == [
             "ExpandedRepeatError: The coordinates for the repeat region are stated incorrectly in the submitted description NM_000088.3:c.589-1G[3]. The corrected description is NM_000088.3:c.589-1_590G[3]",
             "ExpandedRepeatWarning: NM_000088.3:c.589-1_590G[3] should only be used as an annotation for the core HGVS descriptions provided",
@@ -309,9 +309,9 @@ class TestCVariantsExpanded(TestCase):
         variant = 'NM_000088.3:c.589-18T[5]'
         results = self.vv.validate(variant, 'GRCh37', 'all').format_as_dict(test=True)
         print(results)
-        assert results["NM_000088.3:c.589-18_589-14="][
-                   "primary_assembly_loci"]["grch37"]["hgvs_genomic_description"] == "NC_000017.10:g.48275377_48275381="
-        assert results["NM_000088.3:c.589-18_589-14="][
+        assert results["NM_000088.3:c.589-18_589-14T[5]"][
+                   "primary_assembly_loci"]["grch37"]["hgvs_genomic_description"] == "NC_000017.10:g.48275377_48275381A[5]"
+        assert results["NM_000088.3:c.589-18_589-14T[5]"][
                    "validation_warnings"] == [
             "ExpandedRepeatError: The coordinates for the repeat region are stated incorrectly in the submitted description NM_000088.3:c.589-18T[5]. The corrected description is NM_000088.3:c.589-18_589-14T[5]",
             "ExpandedRepeatWarning: NM_000088.3:c.589-18_589-14T[5] should only be used as an annotation for the core HGVS descriptions provided",
@@ -354,13 +354,13 @@ class TestTranscriptVariantsExpandedNvsC(TestCase):
         variant = 'NM_022167.4:c.-1_1GA[1]'
         results = self.vv.validate(variant, 'GRCh37', 'all').format_as_dict(test=True)
         print(results)
-        assert 'NM_022167.4:c.-1_1=' in results
+        assert 'NM_022167.4:c.-1_1GA[1]' in results
 
     def test_coridnates_over_pseudo_cds_start_n(self):
         variant = 'NR_110010.2:n.15_16GA[1]'
         results = self.vv.validate(variant, 'GRCh37', 'all').format_as_dict(test=True)
         print(results)
-        assert 'NR_110010.2:n.15_16=' in results
+        assert 'NR_110010.2:n.15_16GA[1]' in results
 
     def test_cordinateds_over_cds_end_c(self):
         # For this NM_001160367.2 and the following NR_027702.2 test there is a 35bp deletion
@@ -371,14 +371,14 @@ class TestTranscriptVariantsExpandedNvsC(TestCase):
         variant = 'NM_001160367.2:c.870_*1AC[1]'
         results = self.vv.validate(variant, 'GRCh37', 'all').format_as_dict(test=True)
         print(results)
-        assert 'NM_001160367.2:c.870_*1=' in results
+        assert 'NM_001160367.2:c.870_*1AC[1]' in results
 
     def test_cordinateds_over_pseudo_cds_end_n(self):
         # As mentioned n coordinates here should be -35 WRT to n equivalent coordinates for above
         variant = 'NR_027702.2:n.1032_1033AC[1]'
         results = self.vv.validate(variant, 'GRCh37', 'all').format_as_dict(test=True)
         print(results)
-        assert 'NR_027702.2:n.1032_1033=' in results
+        assert 'NR_027702.2:n.1032_1033AC[1]' in results
 
     def test_exon_boundary_single_position_c(self):
         variant = 'NM_022167.4:c.21-4GC[5]'
@@ -412,9 +412,9 @@ class TestTranscriptVariantsExpandedNvsC(TestCase):
         variant = 'NM_022167.4:c.135+1G[2]'
         results = self.vv.validate(variant, 'GRCh37', 'all').format_as_dict(test=True)
         print(results)
-        assert results["NM_022167.4:c.135_135+1="]["primary_assembly_loci"]["grch37"][
-            "hgvs_genomic_description"] == "NC_000017.10:g.48423636_48423637="
-        assert results["NM_022167.4:c.135_135+1="][
+        assert results["NM_022167.4:c.135_135+1G[2]"]["primary_assembly_loci"]["grch37"][
+            "hgvs_genomic_description"] == "NC_000017.10:g.48423636_48423637G[2]"
+        assert results["NM_022167.4:c.135_135+1G[2]"][
             "validation_warnings"] ==  [
             "ExpandedRepeatError: The coordinates for the repeat region are stated incorrectly in the submitted description NM_022167.4:c.135+1G[2]. The corrected description is NM_022167.4:c.135_135+1G[2]",
             "ExpandedRepeatWarning: NM_022167.4:c.135_135+1G[2] should only be used as an annotation for the core HGVS descriptions provided",
@@ -425,9 +425,9 @@ class TestTranscriptVariantsExpandedNvsC(TestCase):
         variant = 'NR_110010.2:n.150+1G[2]'
         results = self.vv.validate(variant, 'GRCh37', 'all').format_as_dict(test=True)
         print(results)
-        assert results["NR_110010.2:n.150_150+1="]["primary_assembly_loci"]["grch37"][
-            "hgvs_genomic_description"] == "NC_000017.10:g.48423636_48423637="
-        assert results["NR_110010.2:n.150_150+1="][
+        assert results["NR_110010.2:n.150_150+1G[2]"]["primary_assembly_loci"]["grch37"][
+            "hgvs_genomic_description"] == "NC_000017.10:g.48423636_48423637G[2]"
+        assert results["NR_110010.2:n.150_150+1G[2]"][
             "validation_warnings"] == [
             "ExpandedRepeatError: The coordinates for the repeat region are stated incorrectly in the submitted description NR_110010.2:n.150+1G[2]. The corrected description is NR_110010.2:n.150_150+1G[2]",
             "ExpandedRepeatWarning: NR_110010.2:n.150_150+1G[2] should only be used as an annotation for the core HGVS descriptions provided",
@@ -438,9 +438,9 @@ class TestTranscriptVariantsExpandedNvsC(TestCase):
         variant = 'NM_022167.4:c.135+6_135+7C[2]'
         results = self.vv.validate(variant, 'GRCh37', 'all').format_as_dict(test=True)
         print(results)
-        assert results["NM_022167.4:c.135+6_135+7="]["primary_assembly_loci"]["grch37"][
-            "hgvs_genomic_description"] == "NC_000017.10:g.48423642_48423643="
-        assert results["NM_022167.4:c.135+6_135+7="][
+        assert results["NM_022167.4:c.135+6_135+7C[2]"]["primary_assembly_loci"]["grch37"][
+            "hgvs_genomic_description"] == "NC_000017.10:g.48423642_48423643C[2]"
+        assert results["NM_022167.4:c.135+6_135+7C[2]"][
             "validation_warnings"] == [
             "ExpandedRepeatWarning: NM_022167.4:c.135+6_135+7C[2] should only be used as an "
             "annotation for the core HGVS descriptions provided",
@@ -451,9 +451,9 @@ class TestTranscriptVariantsExpandedNvsC(TestCase):
         variant = 'NR_110010.2:n.150+6_150+7C[2]'
         results = self.vv.validate(variant, 'GRCh37', 'all').format_as_dict(test=True)
         print(results)
-        assert results["NR_110010.2:n.150+6_150+7="]["primary_assembly_loci"]["grch37"][
-            "hgvs_genomic_description"] == "NC_000017.10:g.48423642_48423643="
-        assert results["NR_110010.2:n.150+6_150+7="][
+        assert results["NR_110010.2:n.150+6_150+7C[2]"]["primary_assembly_loci"]["grch37"][
+            "hgvs_genomic_description"] == "NC_000017.10:g.48423642_48423643C[2]"
+        assert results["NR_110010.2:n.150+6_150+7C[2]"][
             "validation_warnings"] == [
             "ExpandedRepeatWarning: NR_110010.2:n.150+6_150+7C[2] should only be used as an "
             "annotation for the core HGVS descriptions provided",
@@ -482,9 +482,9 @@ class TestTranscriptVariantsExpandedNvsC(TestCase):
         variant = 'NM_022167.4:c.11GC[3]'
         results = self.vv.validate(variant, 'GRCh37', 'all').format_as_dict(test=True)
         print(results)
-        assert results["NM_022167.4:c.11_16="]["primary_assembly_loci"]["grch37"][
-            "hgvs_genomic_description"] == "NC_000017.10:g.48423512_48423517="
-        assert results["NM_022167.4:c.11_16="]["validation_warnings"] ==  [
+        assert results["NM_022167.4:c.11_16GC[3]"]["primary_assembly_loci"]["grch37"][
+            "hgvs_genomic_description"] == "NC_000017.10:g.48423512_48423517GC[3]"
+        assert results["NM_022167.4:c.11_16GC[3]"]["validation_warnings"] ==  [
             "ExpandedRepeatError: The coordinates for the repeat region are stated incorrectly in the submitted description NM_022167.4:c.11GC[3]. The corrected description is NM_022167.4:c.11_16GC[3]",
             "ExpandedRepeatWarning: NM_022167.4:c.11_16GC[3] should only be used as an annotation for the core HGVS descriptions provided"
         ]
@@ -493,9 +493,9 @@ class TestTranscriptVariantsExpandedNvsC(TestCase):
         variant = 'NR_110010.2:n.26GC[3]'
         results = self.vv.validate(variant, 'GRCh37', 'all').format_as_dict(test=True)
         print(results)
-        assert results["NR_110010.2:n.26_31="]["primary_assembly_loci"]["grch37"][
-            "hgvs_genomic_description"] == "NC_000017.10:g.48423512_48423517="
-        assert results["NR_110010.2:n.26_31="]["validation_warnings"] ==  [
+        assert results["NR_110010.2:n.26_31GC[3]"]["primary_assembly_loci"]["grch37"][
+            "hgvs_genomic_description"] == "NC_000017.10:g.48423512_48423517GC[3]"
+        assert results["NR_110010.2:n.26_31GC[3]"]["validation_warnings"] ==  [
             "ExpandedRepeatError: The coordinates for the repeat region are stated incorrectly in the submitted description NR_110010.2:n.26GC[3]. The corrected description is NR_110010.2:n.26_31GC[3]",
             "ExpandedRepeatWarning: NR_110010.2:n.26_31GC[3] should only be used as an annotation for the core HGVS descriptions provided"
         ]
@@ -504,9 +504,9 @@ class TestTranscriptVariantsExpandedNvsC(TestCase):
         variant = 'NM_022167.4:c.11_16GC[3]'
         results = self.vv.validate(variant, 'GRCh37', 'all').format_as_dict(test=True)
         print(results)
-        assert results["NM_022167.4:c.11_16="]["primary_assembly_loci"]["grch37"][
-            "hgvs_genomic_description"] == "NC_000017.10:g.48423512_48423517="
-        assert results["NM_022167.4:c.11_16="]["validation_warnings"] ==  [
+        assert results["NM_022167.4:c.11_16GC[3]"]["primary_assembly_loci"]["grch37"][
+            "hgvs_genomic_description"] == "NC_000017.10:g.48423512_48423517GC[3]"
+        assert results["NM_022167.4:c.11_16GC[3]"]["validation_warnings"] ==  [
             "ExpandedRepeatWarning: NM_022167.4:c.11_16GC[3] should only be used as an annotation for the core HGVS descriptions provided"
         ]
 
@@ -514,9 +514,9 @@ class TestTranscriptVariantsExpandedNvsC(TestCase):
         variant = 'NR_110010.2:n.26_31GC[3]'
         results = self.vv.validate(variant, 'GRCh37', 'all').format_as_dict(test=True)
         print(results)
-        assert results["NR_110010.2:n.26_31="]["primary_assembly_loci"]["grch37"][
-            "hgvs_genomic_description"] == "NC_000017.10:g.48423512_48423517="
-        assert results["NR_110010.2:n.26_31="]["validation_warnings"] == [
+        assert results["NR_110010.2:n.26_31GC[3]"]["primary_assembly_loci"]["grch37"][
+            "hgvs_genomic_description"] == "NC_000017.10:g.48423512_48423517GC[3]"
+        assert results["NR_110010.2:n.26_31GC[3]"]["validation_warnings"] == [
             "ExpandedRepeatWarning: NR_110010.2:n.26_31GC[3] should only be used as an annotation "
             "for the core HGVS descriptions provided",
         ]
@@ -546,9 +546,9 @@ class TestTranscriptVariantsExpandedNvsC(TestCase):
         tr_variant.check_genomic_or_coding()
         results = self.vv.validate(variant, 'GRCh37', 'all').format_as_dict(test=True)
         print(results)
-        assert results["NM_022167.4:c.-13_-11="]["primary_assembly_loci"]["grch37"][
-            "hgvs_genomic_description"] == "NC_000017.10:g.48423489_48423491="
-        assert results["NM_022167.4:c.-13_-11="]["validation_warnings"] ==  [
+        assert results["NM_022167.4:c.-13_-11C[3]"]["primary_assembly_loci"]["grch37"][
+            "hgvs_genomic_description"] == "NC_000017.10:g.48423489_48423491C[3]"
+        assert results["NM_022167.4:c.-13_-11C[3]"]["validation_warnings"] ==  [
             "ExpandedRepeatError: The coordinates for the repeat region are stated incorrectly in the submitted description NM_022167.4:c.-12C[3]. The corrected description is NM_022167.4:c.-13_-11C[3]",
             "ExpandedRepeatWarning: NM_022167.4:c.-13_-11C[3] should only be used as an annotation for the core HGVS descriptions provided"
         ]
@@ -560,9 +560,9 @@ class TestTranscriptVariantsExpandedNvsC(TestCase):
         tr_variant.check_genomic_or_coding()
         results = self.vv.validate(variant, 'GRCh37', 'all').format_as_dict(test=True)
         print(results)
-        assert results["NR_110010.2:n.3_5="]["primary_assembly_loci"]["grch37"][
-            "hgvs_genomic_description"] == "NC_000017.10:g.48423489_48423491="
-        assert results["NR_110010.2:n.3_5="]["validation_warnings"] == [
+        assert results["NR_110010.2:n.3_5C[3]"]["primary_assembly_loci"]["grch37"][
+            "hgvs_genomic_description"] == "NC_000017.10:g.48423489_48423491C[3]"
+        assert results["NR_110010.2:n.3_5C[3]"]["validation_warnings"] == [
             "ExpandedRepeatError: The coordinates for the repeat region are stated incorrectly in the submitted description NR_110010.2:n.3C[3]. The corrected description is NR_110010.2:n.3_5C[3]",
             "ExpandedRepeatWarning: NR_110010.2:n.3_5C[3] should only be used as an annotation for the core HGVS descriptions provided"
         ]
@@ -571,9 +571,9 @@ class TestTranscriptVariantsExpandedNvsC(TestCase):
         variant = 'NM_022167.4:c.-13_-11C[3]'
         results = self.vv.validate(variant, 'GRCh37', 'all').format_as_dict(test=True)
         print(results)
-        assert results["NM_022167.4:c.-13_-11="]["primary_assembly_loci"]["grch37"][
-            "hgvs_genomic_description"] == "NC_000017.10:g.48423489_48423491="
-        assert results["NM_022167.4:c.-13_-11="]["validation_warnings"] == [
+        assert results["NM_022167.4:c.-13_-11C[3]"]["primary_assembly_loci"]["grch37"][
+            "hgvs_genomic_description"] == "NC_000017.10:g.48423489_48423491C[3]"
+        assert results["NM_022167.4:c.-13_-11C[3]"]["validation_warnings"] == [
             "ExpandedRepeatWarning: NM_022167.4:c.-13_-11C[3] should only be used as an annotation "
             "for the core HGVS descriptions provided",
         ]
@@ -582,9 +582,9 @@ class TestTranscriptVariantsExpandedNvsC(TestCase):
         variant = 'NR_110010.2:n.3_5C[3]'
         results = self.vv.validate(variant, 'GRCh37', 'all').format_as_dict(test=True)
         print(results)
-        assert results["NR_110010.2:n.3_5="]["primary_assembly_loci"]["grch37"][
-            "hgvs_genomic_description"] == "NC_000017.10:g.48423489_48423491="
-        assert results["NR_110010.2:n.3_5="]["validation_warnings"] == [
+        assert results["NR_110010.2:n.3_5C[3]"]["primary_assembly_loci"]["grch37"][
+            "hgvs_genomic_description"] == "NC_000017.10:g.48423489_48423491C[3]"
+        assert results["NR_110010.2:n.3_5C[3]"]["validation_warnings"] == [
             "ExpandedRepeatWarning: NR_110010.2:n.3_5C[3] should only be used as an annotation for "
             "the core HGVS descriptions provided",
         ]
@@ -613,9 +613,9 @@ class TestTranscriptVariantsExpandedNvsC(TestCase):
         variant = 'NM_001350922.2:c.240+14_240+21TGGG[2]'
         results = self.vv.validate(variant, 'GRCh37', 'all').format_as_dict(test=True)
         print(results)
-        assert results["NM_001350922.2:c.240+14_240+21="]["primary_assembly_loci"]["grch37"][
-            "hgvs_genomic_description"] == "NC_000010.10:g.128358789_128358796="
-        assert results["NM_001350922.2:c.240+14_240+21="]["validation_warnings"] == [
+        assert results["NM_001350922.2:c.240+14_240+21TGGG[2]"]["primary_assembly_loci"]["grch37"][
+            "hgvs_genomic_description"] == "NC_000010.10:g.128358789_128358796CCCA[2]"
+        assert results["NM_001350922.2:c.240+14_240+21TGGG[2]"]["validation_warnings"] == [
             "ExpandedRepeatWarning: NM_001350922.2:c.240+14_240+21TGGG[2] should only be used as "
             "an annotation for the core HGVS descriptions provided",
             "NM_001350922.2:c.240+14_240+21delinsTGGGTGGG automapped to NM_001350922.2:c.240+14_240+21=",
@@ -625,9 +625,9 @@ class TestTranscriptVariantsExpandedNvsC(TestCase):
         variant = 'NR_146939.2:n.453+14_453+21TGGG[2]'
         results = self.vv.validate(variant, 'GRCh37', 'all').format_as_dict(test=True)
         print(results)
-        assert results["NR_146939.2:n.453+14_453+21="]["primary_assembly_loci"]["grch37"][
-            "hgvs_genomic_description"] == "NC_000010.10:g.128358789_128358796="
-        assert results["NR_146939.2:n.453+14_453+21="]["validation_warnings"] == [
+        assert results["NR_146939.2:n.453+14_453+21TGGG[2]"]["primary_assembly_loci"]["grch37"][
+            "hgvs_genomic_description"] == "NC_000010.10:g.128358789_128358796CCCA[2]"
+        assert results["NR_146939.2:n.453+14_453+21TGGG[2]"]["validation_warnings"] == [
             "ExpandedRepeatWarning: NR_146939.2:n.453+14_453+21TGGG[2] should only be used as an "
             "annotation for the core HGVS descriptions provided",
             "NR_146939.2:n.453+14_453+21delinsTGGGTGGG automapped to NR_146939.2:n.453+14_453+21=",
@@ -637,9 +637,9 @@ class TestTranscriptVariantsExpandedNvsC(TestCase):
         variant = 'NM_001350922.2:c.240+14TGGG[2]'
         results = self.vv.validate(variant, 'GRCh37', 'all').format_as_dict(test=True)
         print(results)
-        assert results["NM_001350922.2:c.240+14_240+21="]["primary_assembly_loci"]["grch37"][
-            "hgvs_genomic_description"] == "NC_000010.10:g.128358789_128358796="
-        assert results["NM_001350922.2:c.240+14_240+21="]["validation_warnings"] == [
+        assert results["NM_001350922.2:c.240+14_240+21TGGG[2]"]["primary_assembly_loci"]["grch37"][
+            "hgvs_genomic_description"] == "NC_000010.10:g.128358789_128358796CCCA[2]"
+        assert results["NM_001350922.2:c.240+14_240+21TGGG[2]"]["validation_warnings"] == [
             "ExpandedRepeatError: The coordinates for the repeat region are stated incorrectly in the submitted description NM_001350922.2:c.240+14TGGG[2]. The corrected description is NM_001350922.2:c.240+14_240+21TGGG[2]",
             "ExpandedRepeatWarning: NM_001350922.2:c.240+14_240+21TGGG[2] should only be used as an annotation for the core HGVS descriptions provided",
             "NM_001350922.2:c.240+14_240+21delinsTGGGTGGG automapped to NM_001350922.2:c.240+14_240+21="
@@ -649,9 +649,9 @@ class TestTranscriptVariantsExpandedNvsC(TestCase):
         variant = 'NR_146939.2:n.453+14TGGG[2]'
         results = self.vv.validate(variant, 'GRCh37', 'all').format_as_dict(test=True)
         print(results)
-        assert results["NR_146939.2:n.453+14_453+21="]["primary_assembly_loci"]["grch37"][
-            "hgvs_genomic_description"] == "NC_000010.10:g.128358789_128358796="
-        assert results["NR_146939.2:n.453+14_453+21="]["validation_warnings"] == [
+        assert results["NR_146939.2:n.453+14_453+21TGGG[2]"]["primary_assembly_loci"]["grch37"][
+            "hgvs_genomic_description"] == "NC_000010.10:g.128358789_128358796CCCA[2]"
+        assert results["NR_146939.2:n.453+14_453+21TGGG[2]"]["validation_warnings"] == [
             "ExpandedRepeatError: The coordinates for the repeat region are stated incorrectly in the submitted description NR_146939.2:n.453+14TGGG[2]. The corrected description is NR_146939.2:n.453+14_453+21TGGG[2]",
             "ExpandedRepeatWarning: NR_146939.2:n.453+14_453+21TGGG[2] should only be used as an annotation for the core HGVS descriptions provided",
             "NR_146939.2:n.453+14_453+21delinsTGGGTGGG automapped to NR_146939.2:n.453+14_453+21="
@@ -661,9 +661,9 @@ class TestTranscriptVariantsExpandedNvsC(TestCase):
         variant = 'NM_001350922.2:c.241-119TC[2]'
         results = self.vv.validate(variant, 'GRCh37', 'all').format_as_dict(test=True)
         print(results)
-        assert results["NM_001350922.2:c.241-121_241-118="]["primary_assembly_loci"]["grch37"][
-            "hgvs_genomic_description"] == "NC_000010.10:g.128335324_128335327="
-        assert results["NM_001350922.2:c.241-121_241-118="]["validation_warnings"] ==  [
+        assert results["NM_001350922.2:c.241-121_241-118TC[2]"]["primary_assembly_loci"]["grch37"][
+            "hgvs_genomic_description"] == "NC_000010.10:g.128335324_128335327GA[2]"
+        assert results["NM_001350922.2:c.241-121_241-118TC[2]"]["validation_warnings"] ==  [
             "ExpandedRepeatError: The coordinates for the repeat region are stated incorrectly in the submitted description NM_001350922.2:c.241-119TC[2]. The corrected description is NM_001350922.2:c.241-121_241-118TC[2]",
             "ExpandedRepeatWarning: NM_001350922.2:c.241-121_241-118TC[2] should only be used as an annotation for the core HGVS descriptions provided",
             "NM_001350922.2:c.241-121_241-118delinsTCTC automapped to NM_001350922.2:c.241-121_241-118="
@@ -673,9 +673,9 @@ class TestTranscriptVariantsExpandedNvsC(TestCase):
         variant = 'NR_146939.2:n.454-119TC[2]'
         results = self.vv.validate(variant, 'GRCh37', 'all').format_as_dict(test=True)
         print(results)
-        assert results["NR_146939.2:n.454-121_454-118="]["primary_assembly_loci"]["grch37"][
-            "hgvs_genomic_description"] == "NC_000010.10:g.128335324_128335327="
-        assert results["NR_146939.2:n.454-121_454-118="]["validation_warnings"] == [
+        assert results["NR_146939.2:n.454-121_454-118TC[2]"]["primary_assembly_loci"]["grch37"][
+            "hgvs_genomic_description"] == "NC_000010.10:g.128335324_128335327GA[2]"
+        assert results["NR_146939.2:n.454-121_454-118TC[2]"]["validation_warnings"] == [
             "ExpandedRepeatError: The coordinates for the repeat region are stated incorrectly in the submitted description NR_146939.2:n.454-119TC[2]. The corrected description is NR_146939.2:n.454-121_454-118TC[2]",
             "ExpandedRepeatWarning: NR_146939.2:n.454-121_454-118TC[2] should only be used as an annotation for the core HGVS descriptions provided",
             "NR_146939.2:n.454-121_454-118delinsTCTC automapped to NR_146939.2:n.454-121_454-118="
@@ -739,9 +739,9 @@ class TestExpandedRepeatGenomic(TestCase):
         variant = 'NC_000022.10:g.24175857_24175865AGA[3]'
         results = self.vv.validate(variant, 'GRCh37', 'all').format_as_dict(test=True)
         print(results)
-        assert results["NM_003073.5:c.1085_1093="]["primary_assembly_loci"]["grch37"][
-            "hgvs_genomic_description"] == "NC_000022.10:g.24175857_24175865="
-        assert results["NM_003073.5:c.1085_1093="]["validation_warnings"] == [
+        assert results["NM_003073.5:c.1085_1093AGA[3]"]["primary_assembly_loci"]["grch37"][
+            "hgvs_genomic_description"] == "NC_000022.10:g.24175857_24175865AGA[3]"
+        assert results["NM_003073.5:c.1085_1093AGA[3]"]["validation_warnings"] == [
             "ExpandedRepeatWarning: NC_000022.10:g.24175857_24175865AGA[3] should only be used as "
             "an annotation for the core HGVS descriptions provided"
         ]
@@ -754,7 +754,7 @@ class TestExpandedRepeatGenomic(TestCase):
         results = self.vv.validate(variant, 'GRCh37', 'all').format_as_dict(test=True)
         print(results)
         assert results["intergenic_variant_1"]["primary_assembly_loci"]["grch37"][
-            "hgvs_genomic_description"] == "NC_000023.10:g.33362724_33362725insAAAAAAAAAAAAAAAA"
+            "hgvs_genomic_description"] == "NC_000023.10:g.33362721_33362724A[20]"
         assert "ExpandedRepeatError: The coordinates for the repeat region are stated incorrectly in the submitted description NC_000023.10:g.33362721A[20]. The corrected description is NC_000023.10:g.33362721_33362724A[20]" in \
                 results['intergenic_variant_1']["validation_warnings"]
 
@@ -787,9 +787,9 @@ class TestExpandedRepeatGenomicToTranscript(TestCase):
         variant = 'NC_000007.13:g.117188661TG[11]'
         results = self.vv.validate(variant, 'GRCh37', 'all').format_as_dict(test=True)
         print(results)
-        assert results["NM_000492.4:c.1210-34_1210-13="]["primary_assembly_loci"]["grch37"][
-            "hgvs_genomic_description"] == "NC_000007.13:g.117188661_117188682="
-        assert results["NM_000492.4:c.1210-34_1210-13="]["validation_warnings"] == [
+        assert results["NM_000492.4:c.1210-34_1210-13TG[11]"]["primary_assembly_loci"]["grch37"][
+            "hgvs_genomic_description"] == "NC_000007.13:g.117188661_117188682TG[11]"
+        assert results["NM_000492.4:c.1210-34_1210-13TG[11]"]["validation_warnings"] == [
             "ExpandedRepeatError: The coordinates for the repeat region are stated incorrectly in the submitted description NC_000007.13:g.117188661TG[11]. The corrected description is NC_000007.13:g.117188661_117188682TG[11]",
             "ExpandedRepeatWarning: NC_000007.13:g.117188661_117188682TG[11] should only be used as an annotation for the core HGVS descriptions provided"
         ]
@@ -799,9 +799,9 @@ class TestExpandedRepeatGenomicToTranscript(TestCase):
         variant = 'NC_000007.13:g.117188661_117188682TG[11]'
         results = self.vv.validate(variant, 'GRCh37', 'all').format_as_dict(test=True)
         print(results)
-        assert results["NM_000492.4:c.1210-34_1210-13="]["primary_assembly_loci"]["grch37"][
-            "hgvs_genomic_description"] == "NC_000007.13:g.117188661_117188682="
-        assert results["NM_000492.4:c.1210-34_1210-13="]["validation_warnings"] == [
+        assert results["NM_000492.4:c.1210-34_1210-13TG[11]"]["primary_assembly_loci"]["grch37"][
+            "hgvs_genomic_description"] == "NC_000007.13:g.117188661_117188682TG[11]"
+        assert results["NM_000492.4:c.1210-34_1210-13TG[11]"]["validation_warnings"] == [
             "ExpandedRepeatWarning: NC_000007.13:g.117188661_117188682TG[11] should only be used "
             "as an annotation for the core HGVS descriptions provided",
         ]
@@ -811,9 +811,9 @@ class TestExpandedRepeatGenomicToTranscript(TestCase):
         variant = 'NC_000022.10:g.24175857AGA[3]'
         results = self.vv.validate(variant, 'GRCh37', 'all').format_as_dict(test=True)
         print(results)
-        assert results["NM_003073.5:c.1085_1093="]["primary_assembly_loci"]["grch37"][
-            "hgvs_genomic_description"] == "NC_000022.10:g.24175857_24175865="
-        assert results["NM_003073.5:c.1085_1093="]["validation_warnings"] ==  [
+        assert results["NM_003073.5:c.1085_1093AGA[3]"]["primary_assembly_loci"]["grch37"][
+            "hgvs_genomic_description"] == "NC_000022.10:g.24175857_24175865AGA[3]"
+        assert results["NM_003073.5:c.1085_1093AGA[3]"]["validation_warnings"] ==  [
             "ExpandedRepeatError: The coordinates for the repeat region are stated incorrectly in the submitted description NC_000022.10:g.24175857AGA[3]. The corrected description is NC_000022.10:g.24175857_24175865AGA[3]",
             "ExpandedRepeatWarning: NC_000022.10:g.24175857_24175865AGA[3] should only be used as an annotation for the core HGVS descriptions provided"
         ]
@@ -823,9 +823,9 @@ class TestExpandedRepeatGenomicToTranscript(TestCase):
         variant = 'NC_000022.10:g.24175857_24175865AGA[3]'
         results = self.vv.validate(variant, 'GRCh37', 'all').format_as_dict(test=True)
         print(results)
-        assert results["NM_003073.5:c.1085_1093="]["primary_assembly_loci"]["grch37"][
-            "hgvs_genomic_description"] == "NC_000022.10:g.24175857_24175865="
-        assert results["NM_003073.5:c.1085_1093="]["validation_warnings"] == [
+        assert results["NM_003073.5:c.1085_1093AGA[3]"]["primary_assembly_loci"]["grch37"][
+            "hgvs_genomic_description"] == "NC_000022.10:g.24175857_24175865AGA[3]"
+        assert results["NM_003073.5:c.1085_1093AGA[3]"]["validation_warnings"] == [
             "ExpandedRepeatWarning: NC_000022.10:g.24175857_24175865AGA[3] should only be used as "
             "an annotation for the core HGVS descriptions provided"
         ]
@@ -835,17 +835,17 @@ class TestExpandedRepeatGenomicToTranscript(TestCase):
         variant = 'NC_000023.10:g.146993569CGG[10]'
         results = self.vv.validate(variant, 'GRCh37', 'all').format_as_dict(test=True)
         print(results)
-        assert results["NM_002024.5:c.-129_-100="]["primary_assembly_loci"]["grch37"][
-            "hgvs_genomic_description"] == "NC_000023.10:g.146993569_146993598="
+        assert results["NM_002024.5:c.-129_-100CGG[10]"]["primary_assembly_loci"]["grch37"][
+            "hgvs_genomic_description"] == "NC_000023.10:g.146993569_146993598CGG[10]"
 
     def test_5_utr_range(self):
         """Reverse of test for 'NM_002024.5:c.-129_-100CGG[10]'"""
         variant = 'NC_000023.10:g.146993569_146993598CGG[10]'
         results = self.vv.validate(variant, 'GRCh37', 'all').format_as_dict(test=True)
         print(results)
-        assert results["NM_002024.5:c.-129_-100="]["primary_assembly_loci"]["grch37"][
-            "hgvs_genomic_description"] == "NC_000023.10:g.146993569_146993598="
-        assert results["NM_002024.5:c.-129_-100="]["validation_warnings"] == [
+        assert results["NM_002024.5:c.-129_-100CGG[10]"]["primary_assembly_loci"]["grch37"][
+            "hgvs_genomic_description"] == "NC_000023.10:g.146993569_146993598CGG[10]"
+        assert results["NM_002024.5:c.-129_-100CGG[10]"]["validation_warnings"] == [
             "ExpandedRepeatWarning: NC_000023.10:g.146993569_146993598CGG[10] should only be used "
             "as an annotation for the core HGVS descriptions provided",
             "TranscriptVersionWarning: A more recent version of the selected reference sequence "
@@ -862,24 +862,20 @@ class TestExpandedRepeatGenomicToTranscript(TestCase):
         results = self.vv.validate(variant, 'GRCh37', 'all').format_as_dict(test=True)
         print(results)
         print(results.keys())
-        assert results["NM_002111.8:c.51_63="]["primary_assembly_loci"]["grch37"][
-            "hgvs_genomic_description"] == "NC_000004.11:g.3076657_3076662dup"
-        assert results["NM_002111.8:c.51_63="]["validation_warnings"] ==  [
-            'ExpandedRepeatWarning: NC_000004.11:g.3076606_3076662GCA[21] should only be used as '
-            'an annotation for the core HGVS descriptions provided',
-            'Submitted description does not represent a true variant because it is an artefact of '
-            'aligning NM_002111.8 with NC_000004.11 (genome build GRCh37)',
-            'NM_002111.8 contains 6 extra bases between c.51_58 than NC_000004.11'
-        ]
+        assert results["NM_001388492.1:c.54_110GCA[21]"]["primary_assembly_loci"]["grch37"][
+            "hgvs_genomic_description"] == "NC_000004.11:g.3076606_3076662GCA[21]"
+        assert (("ExpandedRepeatWarning: NC_000004.11:g.3076606_3076662GCA[21] should only be used as an annotation "
+                "for the core HGVS descriptions provided") in
+                results["NM_001388492.1:c.54_110GCA[21]"]["validation_warnings"])
 
     def test_antisense_intron_range(self):
         """Reverse of test for 'NM_000088.3:c.589-1_590G[3]'"""
         variant = 'NC_000017.10:g.48275362_48275364C[3]'
         results = self.vv.validate(variant, 'GRCh37', 'all').format_as_dict(test=True)
         print(results)
-        assert results["NM_000088.3:c.589-1_590="]["primary_assembly_loci"]["grch37"][
-            "hgvs_genomic_description"] == "NC_000017.10:g.48275362_48275364="
-        assert results["NM_000088.3:c.589-1_590="]["validation_warnings"] == [
+        assert results["NM_000088.3:c.589-1_590G[3]"]["primary_assembly_loci"]["grch37"][
+            "hgvs_genomic_description"] == "NC_000017.10:g.48275362_48275364C[3]"
+        assert results["NM_000088.3:c.589-1_590G[3]"]["validation_warnings"] == [
             "ExpandedRepeatWarning: NC_000017.10:g.48275362_48275364C[3] should only be used as an"
             " annotation for the core HGVS descriptions provided",
             "TranscriptVersionWarning: A more recent version of the selected reference sequence "
@@ -891,16 +887,16 @@ class TestExpandedRepeatGenomicToTranscript(TestCase):
         variant = 'NC_000017.10:g.48275362C[3]'
         results = self.vv.validate(variant, 'GRCh37', 'all').format_as_dict(test=True)
         print(results)
-        assert results["NM_000088.3:c.589-1_590="]["primary_assembly_loci"]["grch37"][
-            "hgvs_genomic_description"] == "NC_000017.10:g.48275362_48275364="
+        assert results["NM_000088.3:c.589-1_590G[3]"]["primary_assembly_loci"]["grch37"][
+            "hgvs_genomic_description"] == "NC_000017.10:g.48275362_48275364C[3]"
 
     def test_antisense_intron_single_pos_2(self):
         """Reverse of test for 'NM_000088.3:c.589-18T[5]'"""
         variant = 'NC_000017.10:g.48275377A[5]'
         results = self.vv.validate(variant, 'GRCh37', 'all').format_as_dict(test=True)
         print(results)
-        assert results["NM_000088.3:c.589-18_589-14="]["primary_assembly_loci"]["grch37"][
-            "hgvs_genomic_description"] == "NC_000017.10:g.48275377_48275381="
+        assert results["NM_000088.3:c.589-18_589-14T[5]"]["primary_assembly_loci"]["grch37"][
+            "hgvs_genomic_description"] == "NC_000017.10:g.48275377_48275381A[5]"
 
 class TestExpandedRepeatRefSeqGenomic(TestCase):
     """
@@ -998,11 +994,11 @@ class TestExpandedRepeatRefSeqGenomic(TestCase):
         variant = 'NM_004006.2:c.-120_-114T[7]'
         results = self.vv.validate(variant, 'GRCh37', 'all').format_as_dict(test=True)
         print(results)
-        assert results["NM_004006.2:c.-120_-114="]["primary_assembly_loci"]["grch37"][
-            "hgvs_genomic_description"] == 'NC_000023.10:g.33229543_33229549='
-        assert results["NM_004006.2:c.-120_-114="]['hgvs_refseqgene_variant']\
-            == 'NG_012232.1:g.133178_133184='
-        assert results["NM_004006.2:c.-120_-114="]["validation_warnings"] ==  [
+        assert results["NM_004006.2:c.-120_-114T[7]"]["primary_assembly_loci"]["grch37"][
+            "hgvs_genomic_description"] == 'NC_000023.10:g.33229543_33229549A[7]'
+        assert results["NM_004006.2:c.-120_-114T[7]"]['hgvs_refseqgene_variant']\
+            == 'NG_012232.1:g.133178_133184T[7]'
+        assert results["NM_004006.2:c.-120_-114T[7]"]["validation_warnings"] ==  [
             'ExpandedRepeatWarning: NM_004006.2:c.-120_-114T[7] should only be used as an '
             'annotation for the core HGVS descriptions provided',
             'TranscriptVersionWarning: A more recent version of the selected reference sequence '
@@ -1017,11 +1013,11 @@ class TestExpandedRepeatRefSeqGenomic(TestCase):
         variant = 'NM_004006.2:c.-120T[7]'
         results = self.vv.validate(variant, 'GRCh37', 'all').format_as_dict(test=True)
         print(results)
-        assert results["NM_004006.2:c.-120_-114="]["primary_assembly_loci"]["grch37"][
-            "hgvs_genomic_description"] == 'NC_000023.10:g.33229543_33229549='
-        assert results["NM_004006.2:c.-120_-114="]['hgvs_refseqgene_variant']\
-            == 'NG_012232.1:g.133178_133184='
-        assert results["NM_004006.2:c.-120_-114="]["validation_warnings"] ==   [
+        assert results["NM_004006.2:c.-120_-114T[7]"]["primary_assembly_loci"]["grch37"][
+            "hgvs_genomic_description"] == 'NC_000023.10:g.33229543_33229549A[7]'
+        assert results["NM_004006.2:c.-120_-114T[7]"]['hgvs_refseqgene_variant']\
+            == 'NG_012232.1:g.133178_133184T[7]'
+        assert results["NM_004006.2:c.-120_-114T[7]"]["validation_warnings"] ==   [
             "ExpandedRepeatError: The coordinates for the repeat region are stated incorrectly in the submitted description NM_004006.2:c.-120T[7]. The corrected description is NM_004006.2:c.-120_-114T[7]",
             "ExpandedRepeatWarning: NM_004006.2:c.-120_-114T[7] should only be used as an annotation for the core HGVS descriptions provided",
             "TranscriptVersionWarning: A more recent version of the selected reference sequence NM_004006.2 is available for genome build GRCh37 (NM_004006.3)"
@@ -1035,15 +1031,15 @@ class TestExpandedRepeatRefSeqGenomic(TestCase):
         variant = 'NM_022167.4:c.135+1G[2]'
         results = self.vv.validate(variant, 'GRCh37', 'all').format_as_dict(test=True)
         print(results)
-        assert results["NM_022167.4:c.135_135+1="]["primary_assembly_loci"]["grch37"][
-            "hgvs_genomic_description"] == "NC_000017.10:g.48423636_48423637="
-        assert results["NM_022167.4:c.135_135+1="]['genome_context_intronic_sequence']\
+        assert results["NM_022167.4:c.135_135+1G[2]"]["primary_assembly_loci"]["grch37"][
+            "hgvs_genomic_description"] == "NC_000017.10:g.48423636_48423637G[2]"
+        assert results["NM_022167.4:c.135_135+1G[2]"]['genome_context_intronic_sequence']\
             == 'NC_000017.10(NM_022167.4):c.135_135+1='
-        assert results["NM_022167.4:c.135_135+1="]['refseqgene_context_intronic_sequence']\
+        assert results["NM_022167.4:c.135_135+1G[2]"]['refseqgene_context_intronic_sequence']\
             == 'NG_012175.1(NM_022167.4):c.135_135+1='
-        assert results["NM_022167.4:c.135_135+1="]['hgvs_refseqgene_variant']\
-            == 'NG_012175.1:g.5244_5245='
-        assert results["NM_022167.4:c.135_135+1="]["validation_warnings"] == [
+        assert results["NM_022167.4:c.135_135+1G[2]"]['hgvs_refseqgene_variant']\
+            == 'NG_012175.1:g.5244_5245G[2]'
+        assert results["NM_022167.4:c.135_135+1G[2]"]["validation_warnings"] == [
             "ExpandedRepeatError: The coordinates for the repeat region are stated incorrectly in the submitted description NM_022167.4:c.135+1G[2]. The corrected description is NM_022167.4:c.135_135+1G[2]",
             "ExpandedRepeatWarning: NM_022167.4:c.135_135+1G[2] should only be used as an annotation for the core HGVS descriptions provided",
             "NM_022167.4:c.135_135+1delinsGG automapped to NM_022167.4:c.135_135+1="
@@ -1057,15 +1053,15 @@ class TestExpandedRepeatRefSeqGenomic(TestCase):
         variant = 'NM_022167.4:c.135_135+1G[2]'
         results = self.vv.validate(variant, 'GRCh37', 'all').format_as_dict(test=True)
         print(results)
-        assert results["NM_022167.4:c.135_135+1="]["primary_assembly_loci"]["grch37"][
-            "hgvs_genomic_description"] == "NC_000017.10:g.48423636_48423637="
-        assert results["NM_022167.4:c.135_135+1="]['genome_context_intronic_sequence']\
+        assert results["NM_022167.4:c.135_135+1G[2]"]["primary_assembly_loci"]["grch37"][
+            "hgvs_genomic_description"] == "NC_000017.10:g.48423636_48423637G[2]"
+        assert results["NM_022167.4:c.135_135+1G[2]"]['genome_context_intronic_sequence']\
             == 'NC_000017.10(NM_022167.4):c.135_135+1='
-        assert results["NM_022167.4:c.135_135+1="]['refseqgene_context_intronic_sequence']\
+        assert results["NM_022167.4:c.135_135+1G[2]"]['refseqgene_context_intronic_sequence']\
             == 'NG_012175.1(NM_022167.4):c.135_135+1='
-        assert results["NM_022167.4:c.135_135+1="]['hgvs_refseqgene_variant']\
-            == 'NG_012175.1:g.5244_5245='
-        assert results["NM_022167.4:c.135_135+1="]["validation_warnings"] == [
+        assert results["NM_022167.4:c.135_135+1G[2]"]['hgvs_refseqgene_variant']\
+            == 'NG_012175.1:g.5244_5245G[2]'
+        assert results["NM_022167.4:c.135_135+1G[2]"]["validation_warnings"] == [
             "ExpandedRepeatWarning: NM_022167.4:c.135_135+1G[2] should only be used as an "
             "annotation for the core HGVS descriptions provided",
             'NM_022167.4:c.135_135+1delinsGG automapped to NM_022167.4:c.135_135+1='
@@ -1194,11 +1190,11 @@ class TestExpandedRepeaLocusReferenceGenomic(TestCase):
         variant = 'LRG_199t1:c.-120T[7]'
         results = self.vv.validate(variant, 'GRCh37', 'all').format_as_dict(test=True)
         print(results)
-        assert results["NM_004006.2:c.-120_-114="]["primary_assembly_loci"]["grch37"][
-            "hgvs_genomic_description"] == 'NC_000023.10:g.33229543_33229549='
-        assert results["NM_004006.2:c.-120_-114="]['hgvs_refseqgene_variant']\
-            == 'NG_012232.1:g.133178_133184='
-        assert results["NM_004006.2:c.-120_-114="]["validation_warnings"] == [
+        assert results["NM_004006.2:c.-120_-114T[7]"]["primary_assembly_loci"]["grch37"][
+            "hgvs_genomic_description"] == 'NC_000023.10:g.33229543_33229549A[7]'
+        assert results["NM_004006.2:c.-120_-114T[7]"]['hgvs_refseqgene_variant']\
+            == 'NG_012232.1:g.133178_133184T[7]'
+        assert results["NM_004006.2:c.-120_-114T[7]"]["validation_warnings"] == [
             "ExpandedRepeatError: The coordinates for the repeat region are stated incorrectly in the submitted description LRG_199t1:c.-120T[7]. The corrected description is NM_004006.2:c.-120_-114T[7]",
             "ExpandedRepeatWarning: NM_004006.2:c.-120_-114T[7] should only be used as an annotation for the core HGVS descriptions provided",
             "TranscriptVersionWarning: A more recent version of the selected reference sequence NM_004006.2 is available for genome build GRCh37 (NM_004006.3)"
@@ -1212,19 +1208,19 @@ class TestExpandedRepeaLocusReferenceGenomic(TestCase):
         variant = 'LRG_199t1:c.31+9A[3]'
         results = self.vv.validate(variant, 'GRCh37', 'all').format_as_dict(test=True)
         print(results)
-        assert results["NM_004006.2:c.31+9_31+11="]["primary_assembly_loci"]["grch37"][
-            "hgvs_genomic_description"] == "NC_000023.10:g.33229388_33229390="
-        assert results["NM_004006.2:c.31+9_31+11="]['genome_context_intronic_sequence']\
+        assert results["NM_004006.2:c.31+9_31+11A[3]"]["primary_assembly_loci"]["grch37"][
+            "hgvs_genomic_description"] == "NC_000023.10:g.33229388_33229390T[3]"
+        assert results["NM_004006.2:c.31+9_31+11A[3]"]['genome_context_intronic_sequence']\
             == 'NC_000023.10(NM_004006.2):c.31+9_31+11='
-        assert results["NM_004006.2:c.31+9_31+11="]['refseqgene_context_intronic_sequence']\
+        assert results["NM_004006.2:c.31+9_31+11A[3]"]['refseqgene_context_intronic_sequence']\
             == 'NG_012232.1(NM_004006.2):c.31+9_31+11='
-        assert results["NM_004006.2:c.31+9_31+11="]['hgvs_lrg_transcript_variant']\
-            == 'LRG_199t1:c.31+9_31+11='
-        assert results["NM_004006.2:c.31+9_31+11="]['hgvs_refseqgene_variant']\
-            == 'NG_012232.1:g.133337_133339='
-        assert results["NM_004006.2:c.31+9_31+11="]['hgvs_lrg_variant']\
-            == 'LRG_199:g.133337_133339='
-        assert results["NM_004006.2:c.31+9_31+11="]["validation_warnings"] ==  [
+        assert results["NM_004006.2:c.31+9_31+11A[3]"]['hgvs_lrg_transcript_variant']\
+            == 'LRG_199t1:c.31+9_31+11A[3]'
+        assert results["NM_004006.2:c.31+9_31+11A[3]"]['hgvs_refseqgene_variant']\
+            == 'NG_012232.1:g.133337_133339A[3]'
+        assert results["NM_004006.2:c.31+9_31+11A[3]"]['hgvs_lrg_variant']\
+            == 'LRG_199:g.133337_133339A[3]'
+        assert results["NM_004006.2:c.31+9_31+11A[3]"]["validation_warnings"] ==  [
             "ExpandedRepeatError: The coordinates for the repeat region are stated incorrectly in the submitted description LRG_199t1:c.31+9A[3]. The corrected description is NM_004006.2:c.31+9_31+11A[3]",
             "ExpandedRepeatWarning: NM_004006.2:c.31+9_31+11A[3] should only be used as an annotation for the core HGVS descriptions provided",
             "NM_004006.2:c.31+9_31+11delinsAAA automapped to NM_004006.2:c.31+9_31+11=",
@@ -1247,9 +1243,9 @@ class TestExpandedRepeaLocusReferenceGenomic(TestCase):
         variant = 'LRG_763t1:c.54GCA[21]'
         results = self.vv.validate(variant, 'GRCh37', 'all').format_as_dict(test=True)
         print(results)
-        assert results["NM_002111.8:c.54_116="]["primary_assembly_loci"]["grch37"][
-            "hgvs_genomic_description"] == "NC_000004.11:g.3076657_3076662dup"
-        assert results["NM_002111.8:c.54_116="]["validation_warnings"] ==   [
+        assert results["NM_002111.8:c.54_116GCA[21]"]["primary_assembly_loci"]["grch37"][
+            "hgvs_genomic_description"] == "NC_000004.11:g.3076606_3076662GCA[21]"
+        assert results["NM_002111.8:c.54_116GCA[21]"]["validation_warnings"] ==   [
             "ExpandedRepeatError: The coordinates for the repeat region are stated incorrectly in the submitted description LRG_763t1:c.54GCA[21]. The corrected description is NM_002111.8:c.54_116GCA[21]",
             "ExpandedRepeatWarning: NM_002111.8:c.54_116GCA[21] should only be used as an annotation for the core HGVS descriptions provided"
         ]

--- a/tests/test_seq_state_to_expanded_repeat.py
+++ b/tests/test_seq_state_to_expanded_repeat.py
@@ -1,0 +1,125 @@
+import unittest
+from vvhgvs import exceptions
+from VariantValidator import Validator
+from VariantValidator.modules import seq_state_to_expanded_repeat
+from VariantValidator.modules.seq_state_to_expanded_repeat import convert_seq_state_to_expanded_repeat, VariantFormatError
+
+class TestExpandedRepeatConversion(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.validator = Validator()
+
+    def test_expanded_repeat_polyA_variant(self):
+        variant = "NC_000023.11:g.33344607_33344608insAAAAAAAAAAAAAAAA"
+        result = convert_seq_state_to_expanded_repeat(variant, self.validator)
+        self.assertEqual(result, "NC_000023.11:g.33344604_33344607A[20]")
+
+    def test_expanded_repeat_polyT_variant(self):
+        variant = "NG_012232.1:g.6_7insTTTTTTTTTTTTTTTT"
+        result = convert_seq_state_to_expanded_repeat(variant, self.validator)
+        self.assertEqual(result, "NG_012232.1:g.3_6T[20]")
+
+    def test_invalid_variant_format_raises(self):
+        with self.assertRaises(VariantFormatError):
+            convert_seq_state_to_expanded_repeat("invalid_variant_string", self.validator)
+
+    def test_missing_colon_format_raises(self):
+        # This will fail because it doesn't contain :g. or :c. etc.
+        variant = "NG_012232.1g.6_7insTTTTTTTTTTTTTTTT"
+        with self.assertRaises(exceptions.HGVSParseError):
+            convert_seq_state_to_expanded_repeat(variant, self.validator)
+
+    def test_no_seq_state_returns_none(self):
+        # A valid variant format but no 'ins', 'del', or 'dup'
+        variant = "NC_000023.11:g.33344607_33344608"
+        with self.assertRaises(VariantFormatError):
+            convert_seq_state_to_expanded_repeat(variant, self.validator)
+
+    def test_expanded_repeat_polyT_variant_alt(self):
+        variant = "NG_012232.1:g.6_7insTTTTTTTTTTTTTTTT"
+        result = convert_seq_state_to_expanded_repeat(variant, self.validator)
+        self.assertEqual(result, "NG_012232.1:g.3_6T[20]")
+
+    def test_expanded_repeat_equal_variant(self):
+        variant = "NM_002111.8:c.54_116="
+        result = convert_seq_state_to_expanded_repeat(variant, self.validator)
+        self.assertEqual(result, "NM_002111.8:c.54_116GCA[21]")
+
+    def test_expanded_repeat_duplication_variant(self):
+        variant = "NM_002111.8:c.54_116dup"
+        result = convert_seq_state_to_expanded_repeat(variant, self.validator)
+        self.assertEqual(result, "NM_002111.8:c.54_116GCA[42]")
+
+    def test_expanded_repeat_deletion_of_one_repeat(self):
+        variant = "NM_002111.8:c.114_116del"
+        result = convert_seq_state_to_expanded_repeat(variant, self.validator)
+        self.assertEqual(result, "NM_002111.8:c.54_116GCA[21]")
+
+    def test_expanded_repeat_deletion_of_two_repeats(self):
+        variant = "NM_002111.8:c.111_116del"
+        result = convert_seq_state_to_expanded_repeat(variant, self.validator)
+        self.assertEqual(result, "NM_002111.8:c.54_116GCA[20]")
+
+    def test_decipher_repeated_unit_non_repeat(self):
+        """Test decipher_repeated_unit with a non-repeating sequence."""
+        result = seq_state_to_expanded_repeat.decipher_repeated_unit("ACGT")
+        self.assertEqual(result, "ACGT")  # Should return full sequence if no repeat found
+
+    def test_decipher_repeated_unit_single_base_repeat(self):
+        """Test decipher_repeated_unit with single-nucleotide repeat."""
+        result = seq_state_to_expanded_repeat.decipher_repeated_unit("AAAAAAAA")
+        self.assertEqual(result, "A")
+
+    def test_start_of_repeat_invalid_repeated_unit(self):
+        with self.assertRaises(seq_state_to_expanded_repeat.RepeatedUnitError):
+            seq_state_to_expanded_repeat.decipher_start_of_full_reference_repeated_sequence("REF", "", 100, self.validator)
+
+    def test_start_of_repeat_invalid_start_position(self):
+        with self.assertRaises(seq_state_to_expanded_repeat.StartPositionError):
+            seq_state_to_expanded_repeat.decipher_start_of_full_reference_repeated_sequence("REF", "A", -10, self.validator)
+
+    def test_end_of_repeat_invalid_repeated_unit(self):
+        with self.assertRaises(seq_state_to_expanded_repeat.RepeatedUnitError):
+            seq_state_to_expanded_repeat.decipher_end_of_full_reference_repeated_sequence("REF", "", 100, self.validator)
+
+    def test_end_of_repeat_invalid_start_position(self):
+        with self.assertRaises(seq_state_to_expanded_repeat.StartPositionError):
+            seq_state_to_expanded_repeat.decipher_end_of_full_reference_repeated_sequence("REF", "A", 0, self.validator)
+
+    def test_expanded_repeat_coding_variant_negative_positions(self):
+        variant = "NM_004006.2:c.-3_1="
+        expected = "NM_004006.2:c.-3_1A[4]"
+
+        result = convert_seq_state_to_expanded_repeat(variant, validator=self.validator)
+        self.assertEqual(result, expected)
+
+    def test_expanded_repeat_noncoding_negative_positions(self):
+        variant = "NR_110010.2:n.15_16="
+        expected = "NR_110010.2:n.15_16GA[1]"
+
+        result = convert_seq_state_to_expanded_repeat(variant, validator=self.validator)
+        self.assertEqual(result, expected)
+
+    def test_expanded_repeat_coding_3utr_positions(self):
+        variant = "NM_001160367.2:c.870_*1="
+        expected = "NM_001160367.2:c.870_*1AC[1]"
+
+        result = convert_seq_state_to_expanded_repeat(variant, validator=self.validator)
+        self.assertEqual(result, expected)
+
+    def test_intronic_coding_sense_strand(self):
+        variant = "NM_000492.4:c.1210-34_1210-13="
+        expected = "NM_000492.4:c.1210-34_1210-13TG[11]"
+
+        result = convert_seq_state_to_expanded_repeat(variant, validator=self.validator, genomic_reference="NC_000007.13")
+        self.assertEqual(result, expected)
+
+    def test_intronic_coding_antisense_strand(self):
+        variant = "NM_000088.3:c.589-1_590="
+        expected = "NM_000088.3:c.589-1_590G[3]"
+
+        result = convert_seq_state_to_expanded_repeat(variant, validator=self.validator, genomic_reference="NC_000017.10")
+        self.assertEqual(result, expected)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_seq_state_to_expanded_repeat.py
+++ b/tests/test_seq_state_to_expanded_repeat.py
@@ -2,7 +2,9 @@ import unittest
 from vvhgvs import exceptions
 from VariantValidator import Validator
 from VariantValidator.modules import seq_state_to_expanded_repeat
-from VariantValidator.modules.seq_state_to_expanded_repeat import convert_seq_state_to_expanded_repeat, VariantFormatError
+from VariantValidator.modules.seq_state_to_expanded_repeat import \
+        convert_seq_state_to_expanded_repeat, VariantFormatError, reassemble_expanded_repeat_variant,\
+        decipher_end_of_full_reference_repeated_sequence,RepeatedUnitError, quick_testfunc
 
 class TestExpandedRepeatConversion(unittest.TestCase):
     @classmethod
@@ -10,53 +12,50 @@ class TestExpandedRepeatConversion(unittest.TestCase):
         cls.validator = Validator()
 
     def test_expanded_repeat_polyA_variant(self):
-        variant = "NC_000023.11:g.33344607_33344608insAAAAAAAAAAAAAAAA"
+        variant = self.validator.hp.parse("NC_000023.11:g.33344607_33344608insAAAAAAAAAAAAAAAA")
         result = convert_seq_state_to_expanded_repeat(variant, self.validator)
         self.assertEqual(result, "NC_000023.11:g.33344604_33344607A[20]")
 
     def test_expanded_repeat_polyT_variant(self):
-        variant = "NG_012232.1:g.6_7insTTTTTTTTTTTTTTTT"
+        variant = self.validator.hp.parse("NG_012232.1:g.6_7insTTTTTTTTTTTTTTTT")
         result = convert_seq_state_to_expanded_repeat(variant, self.validator)
         self.assertEqual(result, "NG_012232.1:g.3_6T[20]")
 
     def test_invalid_variant_format_raises(self):
+        # adjusted for the string-> pre-parsed hgvs object changes
         with self.assertRaises(VariantFormatError):
-            convert_seq_state_to_expanded_repeat("invalid_variant_string", self.validator)
-
-    def test_missing_colon_format_raises(self):
-        # This will fail because it doesn't contain :g. or :c. etc.
-        variant = "NG_012232.1g.6_7insTTTTTTTTTTTTTTTT"
-        with self.assertRaises(exceptions.HGVSParseError):
+            variant = self.validator.hp.parse("NM_002111.8:r.54_116=")
             convert_seq_state_to_expanded_repeat(variant, self.validator)
 
     def test_no_seq_state_returns_none(self):
-        # A valid variant format but no 'ins', 'del', or 'dup'
-        variant = "NC_000023.11:g.33344607_33344608"
+        # A valid variant format but contains a seq change
+        # so can not be == to count * input repeat unit
+        variant = self.validator.hp.parse("NC_000023.11:g.33344607_33344609delinsGGCT")
         with self.assertRaises(VariantFormatError):
             convert_seq_state_to_expanded_repeat(variant, self.validator)
 
     def test_expanded_repeat_polyT_variant_alt(self):
-        variant = "NG_012232.1:g.6_7insTTTTTTTTTTTTTTTT"
+        variant = self.validator.hp.parse("NG_012232.1:g.6_7insTTTTTTTTTTTTTTTT")
         result = convert_seq_state_to_expanded_repeat(variant, self.validator)
         self.assertEqual(result, "NG_012232.1:g.3_6T[20]")
 
     def test_expanded_repeat_equal_variant(self):
-        variant = "NM_002111.8:c.54_116="
+        variant = self.validator.hp.parse("NM_002111.8:c.54_116=")
         result = convert_seq_state_to_expanded_repeat(variant, self.validator)
         self.assertEqual(result, "NM_002111.8:c.54_116GCA[21]")
 
     def test_expanded_repeat_duplication_variant(self):
-        variant = "NM_002111.8:c.54_116dup"
+        variant = self.validator.hp.parse("NM_002111.8:c.54_116dup")
         result = convert_seq_state_to_expanded_repeat(variant, self.validator)
         self.assertEqual(result, "NM_002111.8:c.54_116GCA[42]")
 
     def test_expanded_repeat_deletion_of_one_repeat(self):
-        variant = "NM_002111.8:c.114_116del"
+        variant = self.validator.hp.parse("NM_002111.8:c.114_116del")
         result = convert_seq_state_to_expanded_repeat(variant, self.validator)
         self.assertEqual(result, "NM_002111.8:c.54_116GCA[21]")
 
     def test_expanded_repeat_deletion_of_two_repeats(self):
-        variant = "NM_002111.8:c.111_116del"
+        variant = self.validator.hp.parse("NM_002111.8:c.111_116del")
         result = convert_seq_state_to_expanded_repeat(variant, self.validator)
         self.assertEqual(result, "NM_002111.8:c.54_116GCA[20]")
 
@@ -87,39 +86,144 @@ class TestExpandedRepeatConversion(unittest.TestCase):
             seq_state_to_expanded_repeat.decipher_end_of_full_reference_repeated_sequence("REF", "A", 0, self.validator)
 
     def test_expanded_repeat_coding_variant_negative_positions(self):
-        variant = "NM_004006.2:c.-3_1="
+        variant = self.validator.hp.parse("NM_004006.2:c.-3_1=")
         expected = "NM_004006.2:c.-3_1A[4]"
 
         result = convert_seq_state_to_expanded_repeat(variant, validator=self.validator)
         self.assertEqual(result, expected)
 
     def test_expanded_repeat_noncoding_negative_positions(self):
-        variant = "NR_110010.2:n.15_16="
+        variant = self.validator.hp.parse("NR_110010.2:n.15_16=")
         expected = "NR_110010.2:n.15_16GA[1]"
 
         result = convert_seq_state_to_expanded_repeat(variant, validator=self.validator)
         self.assertEqual(result, expected)
 
     def test_expanded_repeat_coding_3utr_positions(self):
-        variant = "NM_001160367.2:c.870_*1="
+        variant = self.validator.hp.parse("NM_001160367.2:c.870_*1=")
         expected = "NM_001160367.2:c.870_*1AC[1]"
 
         result = convert_seq_state_to_expanded_repeat(variant, validator=self.validator)
         self.assertEqual(result, expected)
 
     def test_intronic_coding_sense_strand(self):
-        variant = "NM_000492.4:c.1210-34_1210-13="
+        variant = self.validator.hp.parse("NM_000492.4:c.1210-34_1210-13=")
         expected = "NM_000492.4:c.1210-34_1210-13TG[11]"
 
         result = convert_seq_state_to_expanded_repeat(variant, validator=self.validator, genomic_reference="NC_000007.13")
         self.assertEqual(result, expected)
 
     def test_intronic_coding_antisense_strand(self):
-        variant = "NM_000088.3:c.589-1_590="
+        variant = self.validator.hp.parse("NM_000088.3:c.589-1_590=")
         expected = "NM_000088.3:c.589-1_590G[3]"
 
         result = convert_seq_state_to_expanded_repeat(variant, validator=self.validator, genomic_reference="NC_000017.10")
         self.assertEqual(result, expected)
+
+    # known_repeat_unit non ins, then ins, then revcomp
+    def test_known_repeat_unit_nonins(self):
+        variant = self.validator.hp.parse("NM_002111.8:c.111_116del")
+        result = convert_seq_state_to_expanded_repeat(variant, self.validator,known_repeat_unit='GCA')
+        self.assertEqual(result, "NM_002111.8:c.54_116GCA[20]")
+
+    def test_known_repeat_unit_ins(self):
+        # normalisation auto expands ins to dup if it can, so test as much as we can here,
+        # see also test_pure_ins_variant
+        variant = self.validator.hp.parse("NM_002111.8:c.116_117insGCA")
+        result = convert_seq_state_to_expanded_repeat(variant, self.validator,known_repeat_unit='GCA')
+        self.assertEqual(result, "NM_002111.8:c.54_116GCA[22]")
+        variant = self.validator.hp.parse("NM_002111.8:c.53_54insGCA")
+        result = convert_seq_state_to_expanded_repeat(variant, self.validator,known_repeat_unit='GCA')
+        self.assertEqual(result, "NM_002111.8:c.54_116GCA[22]")
+        # force to go through latter code as ins because ins > 22 reps, however norms to end of span
+        # hence 53_54 is redundant for now, keep in for testing robustness
+        variant = self.validator.hp.parse("NM_002111.8:c.53_54insGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCA")
+        result = convert_seq_state_to_expanded_repeat(variant, self.validator,known_repeat_unit='GCA')
+        self.assertEqual(result, "NM_002111.8:c.54_116GCA[45]")
+        variant = self.validator.hp.parse("NM_002111.8:c.116_117insGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCA")
+        result = convert_seq_state_to_expanded_repeat(variant, self.validator,known_repeat_unit='GCA')
+        self.assertEqual(result, "NM_002111.8:c.54_116GCA[45]")
+
+    def test_known_repeat_unit(self):
+        variant = self.validator.hp.parse("NM_002111.8:c.111_116del")
+        result = convert_seq_state_to_expanded_repeat(variant, self.validator,known_repeat_unit='TGC')
+        self.assertEqual(result, "NM_002111.8:c.54_116GCA[20]")
+
+    def test_bad_genomic_mapping(self):
+        variant = self.validator.hp.parse("NM_000492.4:c.1210-34_1210-13=")
+        with self.assertRaises(VariantFormatError):
+            result = convert_seq_state_to_expanded_repeat(
+                    variant, validator=self.validator,
+                    genomic_reference="NC_000023.11")
+
+    def test_no_genomic_mapping(self):
+        variant = self.validator.hp.parse("NM_000492.4:c.1210-34_1210-13=")
+        with self.assertRaises(VariantFormatError):
+            result = convert_seq_state_to_expanded_repeat(
+                    variant, validator=self.validator)
+
+    def test_safe_null_variant(self):
+        result = convert_seq_state_to_expanded_repeat(
+                    '', validator=self.validator)
+        assert result == ''
+        result = convert_seq_state_to_expanded_repeat(
+                    None, validator=self.validator)
+        assert result == None
+
+    def test_pure_ins_variant(self):
+        # pure ins should not count as a HGVS Repeated Sequence to quote:
+        # Repeated sequence: a sequence where, compared to a reference sequence,
+        # a segment of one or more nucleotides (the repeat unit) is present
+        # several times, one after the other.
+        variant = self.validator.hp.parse("NM_002111.8:c.116_117insTCTCTC")
+        with self.assertRaises(VariantFormatError):
+            result = convert_seq_state_to_expanded_repeat(
+                    variant, validator=self.validator,known_repeat_unit='TC')
+        variant = self.validator.hp.parse("NM_002111.8:c.116_117insTCTCTC")
+        with self.assertRaises(VariantFormatError):
+            result = convert_seq_state_to_expanded_repeat(
+                    variant, validator=self.validator)
+
+    def test_reassemble_expanded_repeat_variant_input_err(self):
+        # we should never encounter this, but for now test the current behaviour
+        with self.assertRaises(RepeatedUnitError):
+            reassemble_expanded_repeat_variant('','','','', '','','')
+
+    def test_decipher_end_of_full_reference_repeated_sequence_end_lt_zero(self):
+        # this can happen since we try from start - rep length -1 if start = 1
+        # we now avoid starting end fetch from start, so as not to duplicate checks,
+        # but it should still work
+        end = decipher_end_of_full_reference_repeated_sequence('NM_002111.8','GCT', 1, self.validator)
+        assert end == 3
+        # we should never encounter this, seqfetch should already fail at an earlier point in this case,
+        # but for now test the current behaviour
+        end = decipher_end_of_full_reference_repeated_sequence('NM_XXXXXXX.Y','GCT', 6, self.validator)
+        assert end == 6
+
+    def test_internal_quick_test(self):
+        res = quick_testfunc()
+        assert res == 'NM_002111.8:c.54_116GCA[21]'
+
+    def test_bad_genomic_style_attempt(self):
+        # test that bad attempts to map such as those caused by shifted or
+        # changed sequence during mappings external to the expanded repeat code
+        # fail as expected
+        variant = self.validator.hp.parse("NM_002111.8:c.52_116=")
+        with self.assertRaises(VariantFormatError):
+            result = convert_seq_state_to_expanded_repeat(
+                    variant, validator=self.validator, known_repeat_unit='GCA')
+
+    def test_intronic_coding_sense_strand(self):
+        # test that bad attempts to map, specifically like those caused by
+        # changed intronic sequence mappings fail as expected
+        variant = self.validator.hp.parse(
+                "NM_000492.4:c.1210-34_1210-13CGCGCGCGCGCGCGCGCGCGCG=")
+
+        with self.assertRaises(VariantFormatError):
+            result = convert_seq_state_to_expanded_repeat(
+                    variant, validator=self.validator, known_repeat_unit='TG',
+                    genomic_reference="NC_000007.13")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_seq_state_to_expanded_repeat.py
+++ b/tests/test_seq_state_to_expanded_repeat.py
@@ -14,12 +14,12 @@ class TestExpandedRepeatConversion(unittest.TestCase):
     def test_expanded_repeat_polyA_variant(self):
         variant = self.validator.hp.parse("NC_000023.11:g.33344607_33344608insAAAAAAAAAAAAAAAA")
         result = convert_seq_state_to_expanded_repeat(variant, self.validator)
-        self.assertEqual(result, "NC_000023.11:g.33344604_33344607A[20]")
+        self.assertEqual(str(result), "NC_000023.11:g.33344604_33344607A[20]")
 
     def test_expanded_repeat_polyT_variant(self):
         variant = self.validator.hp.parse("NG_012232.1:g.6_7insTTTTTTTTTTTTTTTT")
         result = convert_seq_state_to_expanded_repeat(variant, self.validator)
-        self.assertEqual(result, "NG_012232.1:g.3_6T[20]")
+        self.assertEqual(str(result), "NG_012232.1:g.3_6T[20]")
 
     def test_invalid_variant_format_raises(self):
         # adjusted for the string-> pre-parsed hgvs object changes
@@ -37,27 +37,27 @@ class TestExpandedRepeatConversion(unittest.TestCase):
     def test_expanded_repeat_polyT_variant_alt(self):
         variant = self.validator.hp.parse("NG_012232.1:g.6_7insTTTTTTTTTTTTTTTT")
         result = convert_seq_state_to_expanded_repeat(variant, self.validator)
-        self.assertEqual(result, "NG_012232.1:g.3_6T[20]")
+        self.assertEqual(str(result), "NG_012232.1:g.3_6T[20]")
 
     def test_expanded_repeat_equal_variant(self):
         variant = self.validator.hp.parse("NM_002111.8:c.54_116=")
         result = convert_seq_state_to_expanded_repeat(variant, self.validator)
-        self.assertEqual(result, "NM_002111.8:c.54_116GCA[21]")
+        self.assertEqual(str(result), "NM_002111.8:c.54_116GCA[21]")
 
     def test_expanded_repeat_duplication_variant(self):
         variant = self.validator.hp.parse("NM_002111.8:c.54_116dup")
         result = convert_seq_state_to_expanded_repeat(variant, self.validator)
-        self.assertEqual(result, "NM_002111.8:c.54_116GCA[42]")
+        self.assertEqual(str(result), "NM_002111.8:c.54_116GCA[42]")
 
     def test_expanded_repeat_deletion_of_one_repeat(self):
         variant = self.validator.hp.parse("NM_002111.8:c.114_116del")
         result = convert_seq_state_to_expanded_repeat(variant, self.validator)
-        self.assertEqual(result, "NM_002111.8:c.54_116GCA[21]")
+        self.assertEqual(str(result), "NM_002111.8:c.54_116GCA[21]")
 
     def test_expanded_repeat_deletion_of_two_repeats(self):
         variant = self.validator.hp.parse("NM_002111.8:c.111_116del")
         result = convert_seq_state_to_expanded_repeat(variant, self.validator)
-        self.assertEqual(result, "NM_002111.8:c.54_116GCA[20]")
+        self.assertEqual(str(result), "NM_002111.8:c.54_116GCA[20]")
 
     def test_decipher_repeated_unit_non_repeat(self):
         """Test decipher_repeated_unit with a non-repeating sequence."""
@@ -90,64 +90,64 @@ class TestExpandedRepeatConversion(unittest.TestCase):
         expected = "NM_004006.2:c.-3_1A[4]"
 
         result = convert_seq_state_to_expanded_repeat(variant, validator=self.validator)
-        self.assertEqual(result, expected)
+        self.assertEqual(str(result), expected)
 
     def test_expanded_repeat_noncoding_negative_positions(self):
         variant = self.validator.hp.parse("NR_110010.2:n.15_16=")
         expected = "NR_110010.2:n.15_16GA[1]"
 
         result = convert_seq_state_to_expanded_repeat(variant, validator=self.validator)
-        self.assertEqual(result, expected)
+        self.assertEqual(str(result), expected)
 
     def test_expanded_repeat_coding_3utr_positions(self):
         variant = self.validator.hp.parse("NM_001160367.2:c.870_*1=")
         expected = "NM_001160367.2:c.870_*1AC[1]"
 
         result = convert_seq_state_to_expanded_repeat(variant, validator=self.validator)
-        self.assertEqual(result, expected)
+        self.assertEqual(str(result), expected)
 
     def test_intronic_coding_sense_strand(self):
         variant = self.validator.hp.parse("NM_000492.4:c.1210-34_1210-13=")
         expected = "NM_000492.4:c.1210-34_1210-13TG[11]"
 
         result = convert_seq_state_to_expanded_repeat(variant, validator=self.validator, genomic_reference="NC_000007.13")
-        self.assertEqual(result, expected)
+        self.assertEqual(str(result), expected)
 
     def test_intronic_coding_antisense_strand(self):
         variant = self.validator.hp.parse("NM_000088.3:c.589-1_590=")
         expected = "NM_000088.3:c.589-1_590G[3]"
 
         result = convert_seq_state_to_expanded_repeat(variant, validator=self.validator, genomic_reference="NC_000017.10")
-        self.assertEqual(result, expected)
+        self.assertEqual(str(result), expected)
 
     # known_repeat_unit non ins, then ins, then revcomp
     def test_known_repeat_unit_nonins(self):
         variant = self.validator.hp.parse("NM_002111.8:c.111_116del")
         result = convert_seq_state_to_expanded_repeat(variant, self.validator,known_repeat_unit='GCA')
-        self.assertEqual(result, "NM_002111.8:c.54_116GCA[20]")
+        self.assertEqual(str(result), "NM_002111.8:c.54_116GCA[20]")
 
     def test_known_repeat_unit_ins(self):
         # normalisation auto expands ins to dup if it can, so test as much as we can here,
         # see also test_pure_ins_variant
         variant = self.validator.hp.parse("NM_002111.8:c.116_117insGCA")
         result = convert_seq_state_to_expanded_repeat(variant, self.validator,known_repeat_unit='GCA')
-        self.assertEqual(result, "NM_002111.8:c.54_116GCA[22]")
+        self.assertEqual(str(result), "NM_002111.8:c.54_116GCA[22]")
         variant = self.validator.hp.parse("NM_002111.8:c.53_54insGCA")
         result = convert_seq_state_to_expanded_repeat(variant, self.validator,known_repeat_unit='GCA')
-        self.assertEqual(result, "NM_002111.8:c.54_116GCA[22]")
+        self.assertEqual(str(result), "NM_002111.8:c.54_116GCA[22]")
         # force to go through latter code as ins because ins > 22 reps, however norms to end of span
         # hence 53_54 is redundant for now, keep in for testing robustness
         variant = self.validator.hp.parse("NM_002111.8:c.53_54insGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCA")
         result = convert_seq_state_to_expanded_repeat(variant, self.validator,known_repeat_unit='GCA')
-        self.assertEqual(result, "NM_002111.8:c.54_116GCA[45]")
+        self.assertEqual(str(result), "NM_002111.8:c.54_116GCA[45]")
         variant = self.validator.hp.parse("NM_002111.8:c.116_117insGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCA")
         result = convert_seq_state_to_expanded_repeat(variant, self.validator,known_repeat_unit='GCA')
-        self.assertEqual(result, "NM_002111.8:c.54_116GCA[45]")
+        self.assertEqual(str(result), "NM_002111.8:c.54_116GCA[45]")
 
     def test_known_repeat_unit(self):
         variant = self.validator.hp.parse("NM_002111.8:c.111_116del")
         result = convert_seq_state_to_expanded_repeat(variant, self.validator,known_repeat_unit='TGC')
-        self.assertEqual(result, "NM_002111.8:c.54_116GCA[20]")
+        self.assertEqual(str(result), "NM_002111.8:c.54_116GCA[20]")
 
     def test_bad_genomic_mapping(self):
         variant = self.validator.hp.parse("NM_000492.4:c.1210-34_1210-13=")
@@ -202,7 +202,7 @@ class TestExpandedRepeatConversion(unittest.TestCase):
 
     def test_internal_quick_test(self):
         res = quick_testfunc()
-        assert res == 'NM_002111.8:c.54_116GCA[21]'
+        assert str(res) == 'NM_002111.8:c.54_116GCA[21]'
 
     def test_bad_genomic_style_attempt(self):
         # test that bad attempts to map such as those caused by shifted or

--- a/tests/test_variantformatter_inputs.py
+++ b/tests/test_variantformatter_inputs.py
@@ -6858,10 +6858,10 @@ class TestVFvariantsAuto(object):
                                                                  'GRCh38', 'refseq', "all", False, True, testing=True)
         print(results)
         assert 'NC_000022.11:g.19723410C>G' in results.keys()
-        assert results['NC_000022.11:g.19723410C>G'][
+        pyliftover_assembly_loci = results['NC_000022.11:g.19723410C>G'][
             'NC_000022.11:g.19723410C>G']['hgvs_t_and_p'][
-                   'NM_002688.4']["primary_assembly_loci"] == {
-            "grch37": {
+                'NM_002688.4']["primary_assembly_loci"]
+        assert pyliftover_assembly_loci["grch37"] == {
               "NC_000022.10": {
                 "hgvs_genomic_description": "NC_000022.10:g.19710933C>G",
                 "vcf": {
@@ -6871,8 +6871,8 @@ class TestVFvariantsAuto(object):
                   "ref": "C"
                 }
               }
-            },
-            "grch38": {
+            }
+        assert pyliftover_assembly_loci["grch38"] == {
               "NC_000022.11": {
                 "hgvs_genomic_description": "NC_000022.11:g.19723410C>G",
                 "vcf": {
@@ -6882,19 +6882,22 @@ class TestVFvariantsAuto(object):
                   "ref": "C"
                 }
               }
-            },
-            "hg19": {
-              "NC_000022.10": {
-                "hgvs_genomic_description": "NC_000022.10:g.19710933C>G",
-                "vcf": {
-                  "alt": "G",
-                  "chr": "22",
-                  "pos": "19710933",
-                  "ref": "C"
-                }
-              }
-            },
-            "hg38": {
+            }
+
+        assert "NC_000022.10" in pyliftover_assembly_loci["hg19"]
+        assert pyliftover_assembly_loci["hg19"]["NC_000022.10"][
+                "hgvs_genomic_description"] == "NC_000022.10:g.19710933C>G"
+        assert pyliftover_assembly_loci["hg19"]["NC_000022.10"][
+                "vcf"]["alt"] == "G"
+        assert pyliftover_assembly_loci["hg19"]["NC_000022.10"][
+                "vcf"]["ref"] == "C"
+        assert pyliftover_assembly_loci["hg19"]["NC_000022.10"][
+                "vcf"]["pos"] == "19710933"
+        # chr22 is correct but we used to tolerate 22 so allow both for now
+        assert pyliftover_assembly_loci["hg19"]["NC_000022.10"][
+                "vcf"]["chr"] in ["22", "chr22"]
+
+        assert pyliftover_assembly_loci["hg38"] == {
               "NC_000022.11": {
                 "hgvs_genomic_description": "NC_000022.11:g.19723410C>G",
                 "vcf": {
@@ -6905,17 +6908,16 @@ class TestVFvariantsAuto(object):
                 }
               }
             }
-          }
 
     def test_issue_744b(self):
         results = VariantFormatter.simpleVariantFormatter.format('NC_000012.12:g.80460829T>A',
                                                                  'GRCh38', 'refseq', "raw", False, True, testing=True)
         print(results)
         assert 'NC_000012.12:g.80460829T>A' in results.keys()
-        assert results['NC_000012.12:g.80460829T>A'][
-            'NC_000012.12:g.80460829T>A']['hgvs_t_and_p'][
-                   'NM_001145026.2']["primary_assembly_loci"] == {
-            "grch37": {
+        pyliftover_assembly_loci = results['NC_000012.12:g.80460829T>A'][
+                'NC_000012.12:g.80460829T>A']['hgvs_t_and_p'][
+                   'NM_001145026.2']["primary_assembly_loci"]
+        assert pyliftover_assembly_loci["grch37"] == {
               "NC_000012.11": {
                 "hgvs_genomic_description": "NC_000012.11:g.80860629dup",
                 "vcf": {
@@ -6925,8 +6927,8 @@ class TestVFvariantsAuto(object):
                   "ref": "C"
                 }
               }
-            },
-            "grch38": {
+            }
+        assert pyliftover_assembly_loci["grch38"] == {
               "NC_000012.12": {
                 "hgvs_genomic_description": "NC_000012.12:g.80460829T>A",
                 "vcf": {
@@ -6936,8 +6938,8 @@ class TestVFvariantsAuto(object):
                   "ref": "T"
                 }
               }
-            },
-            "hg19": {
+            }
+        assert pyliftover_assembly_loci["hg19"] == {
               "NC_000012.11": {
                 "hgvs_genomic_description": "NC_000012.11:g.80860629dup",
                 "vcf": {
@@ -6947,8 +6949,8 @@ class TestVFvariantsAuto(object):
                   "ref": "C"
                 }
               }
-            },
-            "hg38": {
+            }
+        assert pyliftover_assembly_loci["hg38"] == {
               "NC_000012.12": {
                 "hgvs_genomic_description": "NC_000012.12:g.80460829T>A",
                 "vcf": {
@@ -6959,7 +6961,6 @@ class TestVFvariantsAuto(object):
                 }
               }
             }
-          }
 
 
 

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -1370,7 +1370,7 @@ class TestVVGapWarnings(TestCase):
         variant = 'NM_002024.5:c.-128_-69GGM[108]'
         results = self.vv.validate(variant, 'GRCh38', 'all', transcript_set="refseq").format_as_dict(test=True)
         print(results)
-        assert "ExpandedRepeatWarning: NM_002024.5:c.-128_-69GGM[108] should only be used as an annotation for the core HGVS descriptions provided" in results['NM_002024.5:c.-126_-69delinsMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGMGGM']['validation_warnings']
+        assert "ExpandedRepeatWarning: NM_002024.5:c.-128_-69GGM[108] should only be used as an annotation for the core HGVS descriptions provided" in results['NM_002024.5:c.-128_-69GGM[108]']['validation_warnings']
 
     def test_issue_698c(self):
         variant = 'NM_002024.5:c.-128_-69GGI[108]'


### PR DESCRIPTION
A version of the Expanded repeat as output, when provided as input, code.  Moved from the old file names, and fixed up to use hgvs objects instead of text input (and output), to avoid costly re-parsing.