### PR TITLE
Vv gapmap insfix alt vcf fix

### DIFF
--- a/VariantValidator/modules/expanded_repeats.py
+++ b/VariantValidator/modules/expanded_repeats.py
@@ -21,6 +21,7 @@ import vvhgvs
 from vvhgvs.alignmentmapper import AlignmentMapper
 from vvhgvs.location import BaseOffsetInterval, Interval
 
+from .transcript_map_data import TranscriptMapData
 from .hgvs_utils import hgvs_delins_parts_to_hgvs_obj, \
         _hgvs_offset_pos_from_str_in
 # Set up logger
@@ -61,6 +62,7 @@ class TandemRepeats:
         build,
         select_transcripts,
         variant_str,
+        map_dat=False
     ):
         """
         This initialised an instance of the class with set class vars.
@@ -91,6 +93,9 @@ class TandemRepeats:
         self.g_strand = 1 # only valid for intronic +/-1
         self.evm = False
         self.no_norm_evm = False
+        self.map_dat = map_dat
+        if not self.map_dat:
+            self.map_dat = TranscriptMapData()
         self.genomic_conversion = None
         self.original_position = None
         self.reference_sequence_bases = None
@@ -490,9 +495,8 @@ class TandemRepeats:
                         f" found {repeat_count} in reference sequence "
                         f"'{seq_check.posedit.edit.ref}'.")
 
-                self.g_strand = validator.hdp.get_tx_exons(
-                        self.reference, intronic_genomic_variant.ac,
-                        validator.alt_aln_method)[0][3]
+                self.g_strand = self.map_dat.map_strand(
+                        self.reference,intronic_genomic_variant.ac,hdp=validator.hdp)
                 # this is re-expanded later from the first base, to handle truncated input
                 if  self.g_strand == -1:
                     self.variant_position.start = copy.copy(self.variant_position.end)
@@ -518,9 +522,8 @@ class TandemRepeats:
                         self.repeat_sequence,
                         )
                 intronic_genomic_variant = self.no_norm_evm.t_to_g(intronic_variant)
-                self.g_strand = validator.hdp.get_tx_exons(
-                        intronic_variant.ac, intronic_genomic_variant.ac,
-                        validator.alt_aln_method)[0][3]
+                self.g_strand = self.map_dat.map_strand(
+                        intronic_variant.ac,intronic_genomic_variant.ac,hdp=validator.hdp)
                 self.variant_position = intronic_genomic_variant.posedit.pos
 
             self.intronic_g_reference = intronic_genomic_variant.ac
@@ -776,9 +779,11 @@ class TandemRepeats:
                 self.original_position.end.offset)):
             return
 
-        exon_data = validator.hdp.get_tx_exons(self.reference,
-                                               self.genomic_conversion.ac,
-                                               validator.alt_aln_method)
+        exon_data = self.map_dat.mapped_exons(
+                self.reference,
+                self.genomic_conversion.ac,
+                hdp=validator.hdp,
+                alt_aln_method=validator.alt_aln_method)
         transcript_exon_pos = []
         if  self.prefix == 'c':
             self._get_c_tx_info(validator)

--- a/VariantValidator/modules/gapped_mapping.py
+++ b/VariantValidator/modules/gapped_mapping.py
@@ -6,9 +6,210 @@ from . import utils as fn
 from . import hgvs_utils
 from . import seq_data
 from VariantValidator.modules.hgvs_utils import hgvs_delins_parts_to_hgvs_obj, hgvs_dup_to_delins
+from VariantValidator.modules.variant import TranscriptMapData
+from VariantValidator.modules.utils import simple_dna_revcomp
 import traceback
 
 logger = logging.getLogger(__name__)
+
+# New function for handling insertion type gapped mappings, relies on, and should only trigger with
+# hgvs mapping improvements, needs to be used before the main GapMapper object
+# no_norm_evm, and map_dat could be sourced from a variant object but will sill
+def immediate_round_trip_gap_ins_handling(
+        orig_hgvs_coding,# transcript mapping
+        orig_hgvs_genomic,# genomic mapping
+        variant_or_validator,# variant or validator, could be either to allow VF liftover usage
+        map_dat=False,): # mapping data for current transcript, will prefer variant data if present
+    """
+    Although G->T is not yet fully fixed T->G in hgvs will correctly handle ins coordinates.
+    Unfortunately correctly expanding the alt when the ref span of origin changes requires a
+    round trip, and so is not handled in hgvs, and may never be, unlike the planned T->G fixes
+    so we try to fix it here.
+    TTTIIICIITTT
+    GGG      GGG
+    where:
+    T is normal genomic transcript map,
+    I is valid transcript sequnce that counts as an insertion WRT the genome, and
+    C is the actual HGVS change
+    current out will be insC not insIIICII (and the exact ins may differ depending
+    on the mapping pair)
+    This function REQUIRES fresh un-normalised mappings as input, normalisation can
+    push G and T variatns away from each other, or worse, the logic complexity
+    required to handle that would be much higher.
+
+    Due to the current code state handling for g->t type input will require creating
+    a 2 base = and mapping (as will non ins change handling if we add it to this
+    function, fully exonic variants are already handled by their nature, but edge
+    spanning variants are not even attempted for now).
+    """
+    no_norm_evm = variant_or_validator.no_norm_evm
+    # map data should either be provided pre-filled or have a hgvs data provider attached
+    map_dat = getattr(variant_or_validator, 'map_dat', map_dat)
+    if not map_dat: # can only happen in validator case so we have a hdp
+        map_dat = TranscriptMapData(hdp=variant_or_validator.hdp)
+    # test for exon edge and escape
+    if getattr(orig_hgvs_coding.posedit.pos.start,'offset',False) or \
+            getattr(orig_hgvs_coding.posedit.pos.start,'offset',False):
+        return orig_hgvs_coding, orig_hgvs_genomic
+    # test for normalised varints and avoid running on them since we rely on the original mappings
+    # here (e.g insTTTCCC->delCCCinsTTTCCC work, but if normalised to insTTT this function fails
+    # hence the "immediate" bit in the name)
+    # start by handling dup and ins
+    hgvs_gen_alt = ''
+    if orig_hgvs_genomic.posedit.edit.type == 'dup':
+        hgvs_gen_alt = orig_hgvs_genomic.posedit.edit.ref + orig_hgvs_genomic.posedit.edit.ref
+        if map_dat.map_strand(orig_hgvs_coding.ac,orig_hgvs_genomic.ac) < 0:
+            hgvs_gen_alt = simple_dna_revcomp(hgvs_gen_alt)
+    elif orig_hgvs_coding.posedit.edit.type  == 'inv':
+        if not map_dat.map_strand(orig_hgvs_coding.ac,orig_hgvs_genomic.ac) < 0:
+            hgvs_gen_alt = simple_dna_revcomp(orig_hgvs_genomic.posedit.edit.ref)
+        else:
+            hgvs_gen_alt = orig_hgvs_genomic.posedit.edit.ref
+    else:
+        #all standard del ins type alt present
+        hgvs_gen_alt = orig_hgvs_genomic.posedit.edit.alt
+    hgvs_tx_alt = ''
+    if orig_hgvs_coding.posedit.edit.type == 'dup':
+        hgvs_tx_alt = orig_hgvs_coding.posedit.edit.ref + orig_hgvs_coding.posedit.edit.ref
+    elif orig_hgvs_coding.posedit.edit.type  == 'inv':
+        hgvs_tx_alt = simple_dna_revcomp(orig_hgvs_coding.posedit.edit.ref)
+    else:
+        #all standard del ins type alt present
+        hgvs_tx_alt = orig_hgvs_coding.posedit.edit.alt
+    if hgvs_tx_alt != hgvs_gen_alt:
+        return orig_hgvs_coding, orig_hgvs_genomic
+
+    if orig_hgvs_genomic.posedit.edit.type == 'ins' and orig_hgvs_coding.posedit.edit.type != 'ins':
+        # size change bases may need to be added to genomic ins
+        eq_hgvs_genomic = copy.copy(orig_hgvs_genomic)
+        eq_hgvs_genomic.posedit.edit.ref = ''
+        eq_hgvs_genomic.posedit.edit.alt = ''
+        remap_hgvs_coding = no_norm_evm.g_to_n(
+                eq_hgvs_genomic,
+                orig_hgvs_coding.ac)
+        if len(orig_hgvs_coding.posedit.edit.ref) +2 < len(remap_hgvs_coding.posedit.edit.ref):
+            # if we got additional non changed ins left out on mapping
+            n_orig_hgvs_coding = orig_hgvs_coding
+            if orig_hgvs_coding.type == 'c':
+                n_orig_hgvs_coding = no_norm_evm.c_to_n(orig_hgvs_coding)
+            start_offset = n_orig_hgvs_coding.posedit.pos.start.base - remap_hgvs_coding.posedit.pos.start.base -1
+            end_offset = remap_hgvs_coding.posedit.pos.end.base - n_orig_hgvs_coding.posedit.pos.end.base -1
+            new_ins = orig_hgvs_coding.posedit.edit.alt
+            if not new_ins:
+                new_ins = ''
+            ins_ref = remap_hgvs_coding.posedit.edit.ref[1:-1]
+            if map_dat.map_strand(orig_hgvs_coding.ac,orig_hgvs_genomic.ac) < 0:
+                ins_ref =  simple_dna_revcomp(ins_ref)
+                spare_offset = start_offset
+                start_offset = end_offset
+                end_offset = spare_offset
+            if start_offset:
+                new_ins = ins_ref[:start_offset] + new_ins
+            if end_offset:
+                new_ins = new_ins +  ins_ref[-end_offset:]
+            new_hgvs_genomic = copy.copy(orig_hgvs_genomic)
+            new_hgvs_genomic.posedit.edit.alt = new_ins
+            return orig_hgvs_coding, new_hgvs_genomic
+        return orig_hgvs_coding, orig_hgvs_genomic
+    elif orig_hgvs_genomic.posedit.edit.type == 'ins' and orig_hgvs_coding.posedit.edit.type == 'ins':
+        # possible size change, bases may need to be added to either
+        # Future proofed, but this should, for now, only happen for T ins mapped to G ins (G ins should
+        # currently fail on T map, handling will likely break the simple coordinate match we rely on for
+        # our logic her so this will be left to older handling code, for now)
+        eq_hgvs_genomic = copy.copy(orig_hgvs_genomic)
+        eq_hgvs_genomic.posedit.edit.ref = ''
+        eq_hgvs_genomic.posedit.edit.alt = ''
+        n_orig_hgvs_coding = orig_hgvs_coding
+        remap_hgvs_coding = no_norm_evm.g_to_n(
+                eq_hgvs_genomic,
+                orig_hgvs_coding.ac)
+        stored_ac = False
+        n_orig_hgvs_coding = orig_hgvs_coding
+        if orig_hgvs_coding.type == 'c':
+            n_orig_hgvs_coding = no_norm_evm.c_to_n(orig_hgvs_coding)
+        if n_orig_hgvs_coding.rel_ac != orig_hgvs_genomic.ac:
+            stored_ac = orig_hgvs_coding.rel_ac
+            n_orig_hgvs_coding.rel_ac = orig_hgvs_genomic.ac
+        remap_hgvs_genomic = no_norm_evm.n_to_g(n_orig_hgvs_coding)
+        if stored_ac:
+            orig_hgvs_coding.rel_ac = stored_ac
+        if remap_hgvs_genomic.posedit.edit.type != 'ins':
+            # should only hapen when pre-map input was genomic, and mapped inside a tx gap
+            start_offset = orig_hgvs_genomic.posedit.pos.start.base - remap_hgvs_genomic.posedit.pos.start.base
+            end_offset = remap_hgvs_genomic.posedit.pos.end.base - orig_hgvs_genomic.posedit.pos.end.base
+            new_ins = orig_hgvs_genomic.posedit.edit.alt
+            if not new_ins:
+                new_ins = ''
+            ins_ref = remap_hgvs_genomic.posedit.edit.ref
+            if map_dat.map_strand(orig_hgvs_coding.ac,orig_hgvs_genomic.ac) < 0:
+                ins_ref =  simple_dna_revcomp(ins_ref)
+                spare_offset = start_offset
+                start_offset = end_offset
+                end_offset = spare_offset
+            if start_offset:
+                new_ins = ins_ref[:start_offset] + new_ins
+            if end_offset:
+                new_ins = new_ins +  ins_ref[-end_offset:]
+            new_hgvs_coding = copy.copy(orig_hgvs_coding)
+            new_hgvs_coding.posedit.edit.alt = new_ins
+            return new_hgvs_coding, orig_hgvs_genomic
+        elif len(remap_hgvs_coding.posedit.edit.ref) > 2:
+            # if we got additional non changed ins left out on mapping
+            n_orig_hgvs_coding = orig_hgvs_coding
+            if orig_hgvs_coding.type == 'c':
+                n_orig_hgvs_coding = no_norm_evm.c_to_n(orig_hgvs_coding)
+            start_offset = n_orig_hgvs_coding.posedit.pos.start.base - remap_hgvs_coding.posedit.pos.start.base -1
+            end_offset = remap_hgvs_coding.posedit.pos.end.base - n_orig_hgvs_coding.posedit.pos.end.base -1
+            new_ins = orig_hgvs_coding.posedit.edit.alt
+            if not new_ins:
+                new_ins = ''
+            ins_ref = remap_hgvs_coding.posedit.edit.ref[1:-1]
+            if map_dat.map_strand(orig_hgvs_coding.ac,orig_hgvs_genomic.ac) < 0:
+                ins_ref =  simple_dna_revcomp(ins_ref)
+                spare_offset = start_offset
+                start_offset = end_offset
+                end_offset = spare_offset
+            if start_offset:
+                new_ins = ins_ref[:start_offset] + new_ins
+            if end_offset:
+                new_ins = new_ins +  ins_ref[-end_offset:]
+            new_hgvs_genomic = copy.copy(orig_hgvs_genomic)
+            new_hgvs_genomic.posedit.edit.alt = new_ins
+            return orig_hgvs_coding, new_hgvs_genomic
+        return orig_hgvs_coding,orig_hgvs_genomic
+    elif orig_hgvs_coding.posedit.edit.type == 'ins': # implicitly genomic != ins
+        if orig_hgvs_coding.type == 'c':
+            n_orig_hgvs_coding = no_norm_evm.c_to_n(orig_hgvs_coding)
+        stored_ac = False
+        if orig_hgvs_coding.rel_ac != orig_hgvs_genomic.ac:
+            stored_ac = orig_hgvs_coding.rel_ac
+            n_orig_hgvs_coding.rel_ac = orig_hgvs_genomic.ac
+        remap_hgvs_genomic = no_norm_evm.n_to_g(n_orig_hgvs_coding)
+        if stored_ac:
+            orig_hgvs_coding.rel_ac = stored_ac
+        if remap_hgvs_genomic.posedit.edit.ref and len(orig_hgvs_genomic.posedit.edit.ref) \
+                < len(remap_hgvs_genomic.posedit.edit.ref):
+            # should only hapen when pre-map input was genomic, and mapped inside a tx gap
+            # Future proofing, current g->t won't do this right
+            start_offset = orig_hgvs_genomic.posedit.pos.start.base - remap_hgvs_genomic.posedit.pos.start.base
+            end_offset = remap_hgvs_genomic.posedit.pos.end.base - orig_hgvs_genomic.posedit.pos.end.base
+            new_ins = orig_hgvs_genomic.posedit.edit.alt
+            if not new_ins:
+                new_ins = ''
+            ins_ref = remap_hgvs_genomic.posedit.edit.ref
+            if map_dat.map_strand(orig_hgvs_coding.ac,orig_hgvs_genomic.ac) < 0:
+                ins_ref =  simple_dna_revcomp(ins_ref)
+                spare_offset = start_offset
+                start_offset = end_offset
+                end_offset = spare_offset
+            if start_offset:
+                new_ins = ins_ref[:start_offset] + new_ins
+            if end_offset:
+                new_ins = new_ins +  ins_ref[-end_offset:]
+            new_hgvs_coding = copy.copy(orig_hgvs_coding)
+            new_hgvs_coding.posedit.edit.alt = new_ins
+            return new_hgvs_coding, orig_hgvs_genomic
+        return orig_hgvs_coding,orig_hgvs_genomic
 
 
 class GapMapper(object):
@@ -2684,6 +2885,8 @@ it is an artefact of aligning %s with %s (genome build %s)""" % (tx_ac, gen_ac, 
         return hgvs_refreshed_variant
 
     def c1_pos_edit(self, hgvs_genomic):
+        # fill the ref of a c type posedit that goes from tx to genome
+        # i.e offset is for end base not start base
         try:
             c1 = self.validator.vm.n_to_c(self.tx_hgvs_not_delins)
         except:
@@ -2712,7 +2915,27 @@ it is an artefact of aligning %s with %s (genome build %s)""" % (tx_ac, gen_ac, 
         g3.posedit.pos.end.base = g2.posedit.pos.end.base
         g3.posedit.edit.ref = reference
         g3.posedit.edit.alt = alternate
-        c3 = self.validator.vm.g_to_t(g3, c1.ac, alt_aln_method=self.validator.alt_aln_method)
+        try:
+            c3 = self.validator.vm.g_to_t(g3, c1.ac, alt_aln_method=self.validator.alt_aln_method)
+        except:
+            c_tx_part = copy.deepcopy(c1)
+            c_tx_part.posedit.pos.end.offset = 0
+            c_tx_part.posedit.edit.alt = ''
+            c_tx_part.posedit.edit.ref = ''
+            self.validator.vm._replace_reference(c_tx_part)
+            c_intronic_part = copy.deepcopy(c1)
+            c_intronic_part.posedit.pos.start.base = c_intronic_part.posedit.pos.end.base
+            c_intronic_part.posedit.pos.start.offset = 0
+            c_intronic_part.posedit.edit.alt = ''
+            c_intronic_part.posedit.edit.ref = ''
+            g_intronic_ref_eq = self.validator.vm.t_to_g(c_intronic_part,hgvs_genomic.ac, alt_aln_method=self.validator.alt_aln_method)
+            if self.orientation == -1:
+                ref =  c_tx_part.posedit.edit.ref + simple_dna_revcomp(g_intronic_ref_eq.posedit.edit.ref)[1:]
+            else:
+                ref = c_tx_part.posedit.edit.ref + g_intronic_ref_eq.posedit.edit.ref[1:]
+            c3 = copy.deepcopy(c1)
+            c3.posedit.edit.ref = ref
+
         hgvs_refreshed_variant = c3
 
         return hgvs_refreshed_variant

--- a/VariantValidator/modules/gapped_mapping.py
+++ b/VariantValidator/modules/gapped_mapping.py
@@ -32,7 +32,10 @@ class GapMapper(object):
     def make_gap_warnings(self, tx_ac, gen_ac, primary_assembly, message=None):
 
         # Look at Cigar strings and calculate the gap size and location
-        tx_exons = self.validator.hdp.get_tx_exons(tx_ac, gen_ac, alt_aln_method=self.validator.alt_aln_method)
+        if not self.variant.map_dat.hdp:
+            self.variant.map_dat.hdp = self.validator.hdp
+        tx_exons = self.variant.map_dat.mapped_exons(
+                tx_ac, gen_ac, alt_aln_method=self.validator.alt_aln_method)
 
         # Locate all the gaps
         gap_in_alignment = []
@@ -185,6 +188,10 @@ it is an artefact of aligning %s with %s (genome build %s)""" % (tx_ac, gen_ac, 
         self.auto_info = ''
         self.disparity_deletion_in = []
 
+        # set map data provider
+        if not self.variant.map_dat.hdp:
+            self.variant.map_dat.hdp = self.validator.hdp
+
         # Create a pseudo VCF so that normalization can be applied and a delins can be generated
         hgvs_genomic_variant = self.variant.hgvs_genomic
 
@@ -213,7 +220,7 @@ it is an artefact of aligning %s with %s (genome build %s)""" % (tx_ac, gen_ac, 
             if hasattr(c.posedit.edit, 'alt') and c.posedit.edit.alt is not None:
                 c.posedit.edit.alt = c.posedit.edit.alt.upper()
             stash_input = self.validator.myevm_t_to_g(c, self.variant.no_norm_evm,
-                                                      self.variant.primary_assembly, self.variant.hn)
+                                                      self.variant.primary_assembly, self.variant.hn, self.variant)
         if stash_input.ac.startswith('NC_') or stash_input.ac.startswith('NT_') or stash_input.ac.startswith('NW_'):
             hgvs_stash = stash_input
             if hasattr(hgvs_stash.posedit.edit, 'ref') and hgvs_stash.posedit.edit.ref is not None:
@@ -313,10 +320,10 @@ it is an artefact of aligning %s with %s (genome build %s)""" % (tx_ac, gen_ac, 
                 else:
                     continue
 
-            # Only apply to known gapped alignment genes
-            symbol = self.validator.db.get_gene_symbol_from_transcript_id(saved_hgvs_coding.ac)
-            if seq_data.gap_black_list(symbol) is True:
-
+            ## Only apply to known gapped alignment mappings
+            if not self.variant.map_dat.hdp:
+                self.variant.map_dat.hdp = self.validator.hdp
+            if self.variant.map_dat.is_gapped_map(saved_hgvs_coding.ac,hgvs_genomic_variant.ac):
                 # Applies to ensembl only
                 if expanded_genomic_for_ensembl is not False:
                     try:
@@ -404,7 +411,7 @@ it is an artefact of aligning %s with %s (genome build %s)""" % (tx_ac, gen_ac, 
                                                                   self.variant.reverse_normalizer,
                                                                   self.validator.sf,
                                                                   saved_hgvs_coding.ac,
-                                                                  self.validator.hdp,
+                                                                  self.variant.map_dat,
                                                                   self.validator.alt_aln_method,
                                                                   self.validator.hp,
                                                                   self.validator.vm,
@@ -430,7 +437,7 @@ it is an artefact of aligning %s with %s (genome build %s)""" % (tx_ac, gen_ac, 
                                                                    self.variant.reverse_normalizer,
                                                                    self.validator.sf,
                                                                    saved_hgvs_coding.ac,
-                                                                   self.validator.hdp,
+                                                                   self.variant.map_dat,
                                                                    self.validator.alt_aln_method,
                                                                    self.validator.hp,
                                                                    self.validator.vm,
@@ -478,8 +485,10 @@ it is an artefact of aligning %s with %s (genome build %s)""" % (tx_ac, gen_ac, 
                                                                          + ref_bases[1]
 
                 # Get orientation of the gene wrt genome and a list of exons mapped to the genome
-                ori = self.validator.tx_exons(tx_ac=saved_hgvs_coding.ac, alt_ac=self.hgvs_genomic_5pr.ac,
-                                              alt_aln_method=self.validator.alt_aln_method)
+                ori = self.variant.map_dat.tx_exons(
+                        saved_hgvs_coding.ac, self.hgvs_genomic_5pr.ac,
+                        self.validator.alt_aln_method,
+                        hdp=self.validator.hdp)
                 try:
                     self.orientation = int(ori[0]['alt_strand'])
                 except TypeError:
@@ -794,7 +803,7 @@ it is an artefact of aligning %s with %s (genome build %s)""" % (tx_ac, gen_ac, 
                                                                                   self.variant.reverse_normalizer,
                                                                                   self.validator.sf,
                                                                                   saved_hgvs_coding.ac,
-                                                                                  self.validator.hdp,
+                                                                                  self.variant.map_dat,
                                                                                   self.validator.alt_aln_method,
                                                                                   self.validator.hp,
                                                                                   self.validator.vm,
@@ -815,7 +824,7 @@ it is an artefact of aligning %s with %s (genome build %s)""" % (tx_ac, gen_ac, 
                                                                                 self.variant.reverse_normalizer,
                                                                                 self.validator.sf,
                                                                                 saved_hgvs_coding.ac,
-                                                                                self.validator.hdp,
+                                                                                self.variant.map_dat,
                                                                                 self.validator.alt_aln_method,
                                                                                 self.validator.hp,
                                                                                 self.validator.vm,
@@ -918,15 +927,19 @@ it is an artefact of aligning %s with %s (genome build %s)""" % (tx_ac, gen_ac, 
 
                 # Otherwise these variants need to be set
                 else:
-                    corrective_action_taken = ''
-                    gapped_alignment_warning = ''
+                    if not gapped_alignment_warning:
+                        gapped_alignment_warning = ''
+                    if not corrective_action_taken:
+                        corrective_action_taken = ''
                     # Send to empty nw_rel_var
                     nw_rel_var.append(saved_hgvs_coding)
 
             # Otherwise these variants need to be set
             else:
-                corrective_action_taken = ''
-                gapped_alignment_warning = ''
+                if not gapped_alignment_warning:
+                    gapped_alignment_warning = ''
+                if not corrective_action_taken:
+                    corrective_action_taken = ''
                 # Send to empty nw_rel_var
                 nw_rel_var.append(saved_hgvs_coding)
 
@@ -944,7 +957,7 @@ it is an artefact of aligning %s with %s (genome build %s)""" % (tx_ac, gen_ac, 
         self.orientation = int(ori[0]['alt_strand'])
         self.hgvs_genomic_possibilities = []
         hgvs_genomic = self.validator.myevm_t_to_g(hgvs_coding, self.variant.no_norm_evm, self.variant.primary_assembly,
-                                                   self.variant.hn)
+                                                   self.variant.hn, self.variant)
 
         logger.debug('g_to_t gap code 1 active')
         rn_hgvs_genomic = self.variant.reverse_normalizer.normalize(hgvs_genomic)
@@ -959,7 +972,8 @@ it is an artefact of aligning %s with %s (genome build %s)""" % (tx_ac, gen_ac, 
             chromosome_normalized_hgvs_coding = hgvs_coding
 
         most_3pr_hgvs_genomic = self.validator.myvm_t_to_g(chromosome_normalized_hgvs_coding, hgvs_genomic.ac,
-                                                           self.variant.no_norm_evm, self.variant.hn)
+                                                           self.variant.no_norm_evm, self.variant.hn,
+                                                           self.variant.map_dat)
         self.hgvs_genomic_possibilities.append([most_3pr_hgvs_genomic, ['false', 'false']])
 
         # Push from side to side to try pick up odd placements
@@ -969,6 +983,9 @@ it is an artefact of aligning %s with %s (genome build %s)""" % (tx_ac, gen_ac, 
         stash_tx_right = ''
         stash_tx_left = ''
         map_fail = False
+        if not self.variant.map_dat.hdp:
+            self.variant.map_dat.hdp = self.validator.hdp
+
         try:
             if hgvs_stash.type == 'c':
                 hgvs_stash = self.validator.vm.c_to_n(hgvs_stash)
@@ -1001,7 +1018,7 @@ it is an artefact of aligning %s with %s (genome build %s)""" % (tx_ac, gen_ac, 
                                                         self.variant.reverse_normalizer,
                                                         self.validator.sf,
                                                         hgvs_coding.ac,
-                                                        self.validator.hdp,
+                                                        self.variant.map_dat,
                                                         self.validator.alt_aln_method,
                                                         self.validator.hp,
                                                         self.validator.vm,
@@ -1022,7 +1039,7 @@ it is an artefact of aligning %s with %s (genome build %s)""" % (tx_ac, gen_ac, 
 
             test_stash_tx_right = copy.deepcopy(stash_hgvs_not_delins)
             stash_genomic = self.validator.myvm_t_to_g(test_stash_tx_right, hgvs_genomic.ac, self.variant.no_norm_evm,
-                                                       self.variant.hn)
+                                                       self.variant.hn,self.variant.map_dat)
             if len(test_stash_tx_right.posedit.edit.ref) == (
                     (stash_genomic.posedit.pos.end.base - stash_genomic.posedit.pos.start.base) + 1):
                 stash_tx_right = test_stash_tx_right
@@ -1084,8 +1101,8 @@ it is an artefact of aligning %s with %s (genome build %s)""" % (tx_ac, gen_ac, 
                     except (TypeError, vvhgvs.exceptions.HGVSInvalidVariantError):
                         pass
                     stash_genomic = self.validator.myvm_t_to_g(identifying_variant, stash_genomic.ac,
-                                                               self.variant.no_norm_evm,
-                                                               self.variant.hn)
+                                                               self.variant.no_norm_evm,self.variant.hn,
+                                                               self.variant.map_dat)
                     stash_hgvs_not_delins = merged_variant
                     test_stash_tx_right = merged_variant
 
@@ -1131,7 +1148,7 @@ it is an artefact of aligning %s with %s (genome build %s)""" % (tx_ac, gen_ac, 
                                                        self.variant.reverse_normalizer,
                                                        self.validator.sf,
                                                        hgvs_coding.ac,
-                                                       self.validator.hdp,
+                                                       self.variant.map_dat,
                                                        self.validator.alt_aln_method,
                                                        self.validator.hp,
                                                        self.validator.vm,
@@ -1152,7 +1169,7 @@ it is an artefact of aligning %s with %s (genome build %s)""" % (tx_ac, gen_ac, 
                 # Store a tx copy for later use
             test_stash_tx_left = copy.deepcopy(stash_hgvs_not_delins)
             stash_genomic = self.validator.myvm_t_to_g(test_stash_tx_left, hgvs_genomic.ac, self.variant.no_norm_evm,
-                                                       self.variant.hn)
+                                                       self.variant.hn,self.variant.map_dat)
 
             if len(test_stash_tx_left.posedit.edit.ref) == ((stash_genomic.posedit.pos.end.base -
                                                              stash_genomic.posedit.pos.start.base) + 1):
@@ -1216,8 +1233,8 @@ it is an artefact of aligning %s with %s (genome build %s)""" % (tx_ac, gen_ac, 
                     except (TypeError, vvhgvs.exceptions.HGVSInvalidVariantError):
                         pass
                     stash_genomic = self.validator.myvm_t_to_g(identifying_variant, stash_genomic.ac,
-                                                               self.variant.no_norm_evm,
-                                                               self.variant.hn)
+                                                               self.variant.no_norm_evm,self.variant.hn,
+                                                               self.variant.map_dat)
                     stash_hgvs_not_delins = merged_variant
                     test_stash_tx_left = merged_variant
 
@@ -1502,8 +1519,9 @@ it is an artefact of aligning %s with %s (genome build %s)""" % (tx_ac, gen_ac, 
                                                    alt_aln_method=self.validator.alt_aln_method)
                     if (rtx.posedit.pos.start.offset == 0 and rtx.posedit.pos.end.offset == 0) and (
                             ftx.posedit.pos.start.offset != 0 and ftx.posedit.pos.end.offset != 0):
-                        exons = self.validator.hdp.get_tx_exons(ftx.ac, hgvs_not_delins.ac,
-                                                                self.validator.alt_aln_method)
+                        exons = self.variant.map_dat.mapped_exons(
+                                ftx.ac, hgvs_not_delins.ac,
+                                alt_aln_method=self.validator.alt_aln_method)
                         exonic = False
                         for ex_test in exons:
                             if ftx.posedit.pos.start.base in range(ex_test[6], ex_test[
@@ -1596,7 +1614,8 @@ it is an artefact of aligning %s with %s (genome build %s)""" % (tx_ac, gen_ac, 
                 if hard_set_outputs is not True:
                     # Update hgvs_genomic
                     hgvs_genomic = self.validator.myvm_t_to_g(hgvs_refreshed_variant, hgvs_genomic.ac,
-                                                              self.variant.no_norm_evm, self.variant.hn)
+                                                              self.variant.no_norm_evm, self.variant.hn,
+                                                              self.variant.map_dat)
                     if hgvs_genomic.posedit.edit.type == 'identity':
                         re_c = self.validator.vm.g_to_t(hgvs_genomic, hgvs_refreshed_variant.ac,
                                                         alt_aln_method=self.validator.alt_aln_method)
@@ -1805,13 +1824,16 @@ it is an artefact of aligning %s with %s (genome build %s)""" % (tx_ac, gen_ac, 
                 chromosome_normalized_hgvs_coding = hgvs_coding
 
         most_3pr_hgvs_genomic = self.validator.myvm_t_to_g(chromosome_normalized_hgvs_coding, alt_chr,
-                                                           self.variant.no_norm_evm, self.variant.hn)
+                                                           self.variant.no_norm_evm, self.variant.hn,
+                                                           self.variant.map_dat)
         self.hgvs_genomic_possibilities.append([most_3pr_hgvs_genomic, ['false', 'false']])
 
         # First to the right
         hgvs_stash = copy.deepcopy(hgvs_coding)
         stash_tx_right = ''
         stash_tx_left = ''
+        if not self.variant.map_dat.hdp:
+            self.variant.map_dat.hdp = self.validator.hdp
 
         # Capture instances where variant merging hard-sets the outputs
         map_fail = False
@@ -1848,7 +1870,7 @@ it is an artefact of aligning %s with %s (genome build %s)""" % (tx_ac, gen_ac, 
                                                         self.variant.reverse_normalizer,
                                                         self.validator.sf,
                                                         hgvs_coding.ac,
-                                                        self.validator.hdp,
+                                                        self.variant.map_dat,
                                                         self.validator.alt_aln_method,
                                                         self.validator.hp,
                                                         self.validator.vm,
@@ -1871,7 +1893,8 @@ it is an artefact of aligning %s with %s (genome build %s)""" % (tx_ac, gen_ac, 
             # Store a tx copy for later use
             test_stash_tx_right = copy.deepcopy(stash_hgvs_not_delins)
             stash_genomic = self.validator.myvm_t_to_g(test_stash_tx_right, hgvs_alt_genomic.ac,
-                                                       self.variant.no_norm_evm, self.variant.hn)
+                                                       self.variant.no_norm_evm, self.variant.hn,
+                                                       self.variant.map_dat)
 
             if len(test_stash_tx_right.posedit.edit.ref) == ((stash_genomic.posedit.pos.end.base -
                                                               stash_genomic.posedit.pos.start.base) + 1):
@@ -1933,8 +1956,8 @@ it is an artefact of aligning %s with %s (genome build %s)""" % (tx_ac, gen_ac, 
                         pass
 
                     stash_genomic = self.validator.myvm_t_to_g(identifying_variant, stash_genomic.ac,
-                                                               self.variant.no_norm_evm,
-                                                               self.variant.hn)
+                                                               self.variant.no_norm_evm,self.variant.hn,
+                                                               self.variant.map_dat)
                     stash_hgvs_not_delins = merged_variant
                     test_stash_tx_right = merged_variant
 
@@ -1980,7 +2003,7 @@ it is an artefact of aligning %s with %s (genome build %s)""" % (tx_ac, gen_ac, 
                                                        self.variant.reverse_normalizer,
                                                        self.validator.sf,
                                                        hgvs_coding.ac,
-                                                       self.validator.hdp,
+                                                       self.variant.map_dat,
                                                        self.validator.alt_aln_method,
                                                        self.validator.hp,
                                                        self.validator.vm,
@@ -2002,7 +2025,8 @@ it is an artefact of aligning %s with %s (genome build %s)""" % (tx_ac, gen_ac, 
                 # Store a tx copy for later use
             test_stash_tx_left = copy.deepcopy(stash_hgvs_not_delins)
             stash_genomic = self.validator.myvm_t_to_g(test_stash_tx_left, hgvs_alt_genomic.ac,
-                                                  self.variant.no_norm_evm, self.variant.hn)
+                                                       self.variant.no_norm_evm, self.variant.hn,
+                                                       self.variant.map_dat)
 
             if len(test_stash_tx_left.posedit.edit.ref) == ((stash_genomic.posedit.pos.end.base -
                                                              stash_genomic.posedit.pos.start.base) + 1):
@@ -2064,8 +2088,8 @@ it is an artefact of aligning %s with %s (genome build %s)""" % (tx_ac, gen_ac, 
                         pass
 
                     stash_genomic = self.validator.myvm_t_to_g(identifying_variant, stash_genomic.ac,
-                                                               self.variant.no_norm_evm,
-                                                               self.variant.hn)
+                                                               self.variant.no_norm_evm,self.variant.hn,
+                                                               self.variant.map_dat)
                     stash_hgvs_not_delins = merged_variant
                     test_stash_tx_left = merged_variant
 
@@ -2334,8 +2358,10 @@ it is an artefact of aligning %s with %s (genome build %s)""" % (tx_ac, gen_ac, 
                                                    alt_aln_method=self.validator.alt_aln_method)
                     if (rtx.posedit.pos.start.offset == 0 and rtx.posedit.pos.end.offset == 0) and (
                             ftx.posedit.pos.start.offset != 0 and ftx.posedit.pos.end.offset != 0):
-                        exons = self.validator.hdp.get_tx_exons(ftx.ac, hgvs_not_delins.ac,
-                                                                alt_aln_method=self.validator.alt_aln_method)
+                        exons = self.variant.map_dat.mapped_exons(
+                                ftx.ac, hgvs_not_delins.ac,
+                                alt_aln_method=self.validator.alt_aln_method)
+
                         exonic = False
                         for ex_test in exons:
                             if ftx.posedit.pos.start.base in range(ex_test[6], ex_test[7]) and \
@@ -2418,7 +2444,8 @@ it is an artefact of aligning %s with %s (genome build %s)""" % (tx_ac, gen_ac, 
                 if hard_set_outputs is False:
                     # Update hgvs_genomic
                     hgvs_alt_genomic = self.validator.myvm_t_to_g(hgvs_refreshed_variant, alt_chr,
-                                                                  self.variant.no_norm_evm, self.variant.hn)
+                                                                  self.variant.no_norm_evm, self.variant.hn,
+                                                                  self.variant.map_dat)
                     if hgvs_alt_genomic.posedit.edit.type == 'identity':
                         re_c = self.validator.vm.g_to_t(hgvs_alt_genomic, hgvs_refreshed_variant.ac,
                                                         alt_aln_method=self.validator.alt_aln_method)
@@ -2473,7 +2500,8 @@ it is an artefact of aligning %s with %s (genome build %s)""" % (tx_ac, gen_ac, 
             check_flank_genomic = self.validator.myvm_t_to_g(hgvs_refreshed_variant,
                                                              hgvs_alt_genomic.ac,
                                                              self.variant.no_norm_evm,
-                                                             self.variant.hn)
+                                                             self.variant.hn,
+                                                             self.variant.map_dat)
 
             if ((hgvs_alt_genomic.posedit.edit.type == hgvs_refreshed_variant.posedit.edit.type and
                     hgvs_alt_genomic.posedit.edit.type == "sub") and
@@ -2575,7 +2603,8 @@ it is an artefact of aligning %s with %s (genome build %s)""" % (tx_ac, gen_ac, 
             test_tx_var = rn_tx_hgvs_not_delins
         # re-make genomic and tx
         hgvs_not_delins = self.validator.myevm_t_to_g(test_tx_var, self.variant.no_norm_evm,
-                                                      self.variant.primary_assembly, self.variant.hn)
+                                                      self.variant.primary_assembly, self.variant.hn,
+                                                      self.variant)
         rn_tx_hgvs_not_delins = self.variant.no_norm_evm.g_to_n(hgvs_not_delins,
                                                                 str(saved_hgvs_coding.ac))
         return rn_tx_hgvs_not_delins, hgvs_not_delins
@@ -2604,7 +2633,8 @@ it is an artefact of aligning %s with %s (genome build %s)""" % (tx_ac, gen_ac, 
 
         # re-make genomic and tx
         hgvs_not_delins = self.validator.myevm_t_to_g(test_tx_var, self.variant.no_norm_evm,
-                                                      self.variant.primary_assembly, self.variant.hn)
+                                                      self.variant.primary_assembly, self.variant.hn,
+                                                      self.variant)
 
         try:
             rn_tx_hgvs_not_delins = self.variant.no_norm_evm.g_to_n(hgvs_not_delins,

--- a/VariantValidator/modules/hgvs_utils.py
+++ b/VariantValidator/modules/hgvs_utils.py
@@ -1533,7 +1533,7 @@ def hard_right_hgvs2vcf(hgvs_genomic, primary_assembly, hn, reverse_normalizer, 
             if normlize_check_mapped.posedit.pos.start.base > normlize_check_mapped.posedit.pos.end.base:
                 needs_a_push = False
                 break
-            if len(normlize_check_mapped.posedit.edit.ref) <= 1:
+            if not normlize_check_mapped.posedit.edit.ref or len(normlize_check_mapped.posedit.edit.ref) <= 1:
                 staging_loop = staging_loop + 1
 
             # exon boundary hit. Break before intron
@@ -1542,12 +1542,12 @@ def hard_right_hgvs2vcf(hgvs_genomic, primary_assembly, hn, reverse_normalizer, 
                 break
 
             # Check here for the gap (Has it been crossed?) Note: if gap in tx, we have the whole gap spanned
-            elif (((len(normlize_check_mapped.posedit.edit.ref) != len(normlize_check_variant.posedit.edit.ref) and
-                  len(normlize_check_mapped.posedit.edit.ref) > 1))
-                    or
-                    (normlize_check_variant.posedit.edit.type == 'identity')
-                    and len(normlize_check_mapped.posedit.edit.alt) != len(normlize_check_variant.posedit.edit.ref)):
-
+            elif (normlize_check_mapped.posedit.edit.ref and
+                  ((len(normlize_check_mapped.posedit.edit.ref) != len(normlize_check_variant.posedit.edit.ref) and
+                    len(normlize_check_mapped.posedit.edit.ref) > 1))
+                  or
+                  (normlize_check_variant.posedit.edit.type == 'identity')
+                  and len(normlize_check_mapped.posedit.edit.alt) != len(normlize_check_variant.posedit.edit.ref)):
                 # Add the identifying variant
                 identifying_variant = normlize_check_variant
 
@@ -2194,11 +2194,14 @@ def hard_left_hgvs2vcf(hgvs_genomic, primary_assembly, hn, reverse_normalizer, s
             if normlize_check_mapped.posedit.pos.start.base > normlize_check_mapped.posedit.pos.end.base:
                 needs_a_push = False
                 break
-            if len(normlize_check_mapped.posedit.edit.ref) <= 1:
+
+            if not normlize_check_mapped.posedit.edit.ref or len(normlize_check_mapped.posedit.edit.ref) <= 1:
                 staging_loop = staging_loop + 1
 
             # Check here for the gap (Has it been crossed?) Note: if gap in tx, we have the whole gap spanned
-            if (((len(normlize_check_mapped.posedit.edit.ref) != len(normlize_check_variant.posedit.edit.ref) and
+            #
+            if ((normlize_check_mapped.posedit.edit.ref and
+                (len(normlize_check_mapped.posedit.edit.ref) != len(normlize_check_variant.posedit.edit.ref) and
                   len(normlize_check_mapped.posedit.edit.ref) > 1))
                     or
                     (normlize_check_variant.posedit.edit.type == 'identity')

--- a/VariantValidator/modules/hgvs_utils.py
+++ b/VariantValidator/modules/hgvs_utils.py
@@ -19,6 +19,7 @@ from vvhgvs.enums import Datum
 from vvhgvs.location import AAPosition
 from vvhgvs.edit import AASub, AARefAlt, Dup, NARefAlt
 from vvhgvs.posedit import PosEdit
+from .transcript_map_data import TranscriptMapData
 
 # Database connections and hgvs objects are now passed from VariantValidator.py
 
@@ -1286,7 +1287,7 @@ def pre_push_vcf_tx_g_map_fix(norm_hgvs_transcript, un_norm_hgvs, genomic_ac,var
 
 
 
-def hard_right_hgvs2vcf(hgvs_genomic, primary_assembly, hn, reverse_normalizer, sf, tx_ac, hdp, alt_aln_method, hp, vm,
+def hard_right_hgvs2vcf(hgvs_genomic, primary_assembly, hn, reverse_normalizer, sf, tx_ac, map_dat, alt_aln_method, hp, vm,
                         mrg, genomic_ac=False, mapped_g=False, pre_norm=False):
     """
     Designed specifically for gap handling.
@@ -1297,7 +1298,7 @@ def hard_right_hgvs2vcf(hgvs_genomic, primary_assembly, hn, reverse_normalizer, 
     :param reverse_normalizer:
     :param sf:
     :param tx_ac: Transcipt ac when genomic var is input
-    :param hdp:
+    :param map_dat: cached fetcher/store for transcript mapping data
     :param alt_aln_method:
     :param hp:
     :param vm:
@@ -1451,7 +1452,8 @@ def hard_right_hgvs2vcf(hgvs_genomic, primary_assembly, hn, reverse_normalizer, 
         # Set exon boundary
         if genomic_ac is False:
             # Find the boundaries at the genomic level for the current exon
-            exon_set = hdp.get_tx_exons(tx_ac, hgvs_genomic.ac, alt_aln_method)
+            exon_set = map_dat.mapped_exons(
+                    tx_ac, hgvs_genomic.ac, alt_aln_method=alt_aln_method)
             exon_end_genomic = None
             for exon in exon_set:
                 if int(exon[7]) + 1 <= int(pos) <= int(exon[8]):
@@ -1459,7 +1461,8 @@ def hard_right_hgvs2vcf(hgvs_genomic, primary_assembly, hn, reverse_normalizer, 
                     break
         else:
             # Trick the system using transcript positions
-            exon_set = hdp.get_tx_exons(hgvs_genomic.ac, genomic_ac, alt_aln_method)
+            exon_set = map_dat.mapped_exons(
+                    hgvs_genomic.ac, genomic_ac, alt_aln_method=alt_aln_method)
             exon_end_genomic = None
             for exon in exon_set:
                 if int(exon[5]) + 1 <= int(pos) <= int(exon[6]):
@@ -1694,9 +1697,9 @@ def hard_right_hgvs2vcf(hgvs_genomic, primary_assembly, hn, reverse_normalizer, 
                         else:
                             try:
                                 if v1.posedit.pos.start.base < v2.posedit.pos.start.base:
-                                    pre_merged_variant = mrg([v1, v2], reverse_normalizer, final_norm=False)
+                                    pre_merged_variant = mrg([v1, v2], reverse_normalizer, final_norm=False, map_dat=map_dat)
                                 else:
-                                    pre_merged_variant = mrg([v2, v1], reverse_normalizer, final_norm=False)
+                                    pre_merged_variant = mrg([v2, v1], reverse_normalizer, final_norm=False, map_dat=map_dat)
                                 if "g" in pre_merged_variant.type:
                                     merged_variant = vm.g_to_n(pre_merged_variant, tx_ac)
                                 else:
@@ -1874,9 +1877,9 @@ def hard_right_hgvs2vcf(hgvs_genomic, primary_assembly, hn, reverse_normalizer, 
                         else:
                             try:
                                 if v1.posedit.pos.start.base < v2.posedit.pos.start.base:
-                                    pre_merged_variant = mrg([v1, v2], reverse_normalizer, final_norm=False)
+                                    pre_merged_variant = mrg([v1, v2], reverse_normalizer, final_norm=False, map_dat=map_dat)
                                 else:
-                                    pre_merged_variant = mrg([v2, v1], reverse_normalizer, final_norm=False)
+                                    pre_merged_variant = mrg([v2, v1], reverse_normalizer, final_norm=False, map_dat=map_dat)
                                 if "g" in pre_merged_variant.type:
                                     merged_variant = vm.g_to_n(pre_merged_variant, tx_ac)
                                 else:
@@ -1884,9 +1887,9 @@ def hard_right_hgvs2vcf(hgvs_genomic, primary_assembly, hn, reverse_normalizer, 
                             except utils.mergeHGVSerror:
                                 try:
                                     if v1.posedit.pos.start.base < v2.posedit.pos.start.base:
-                                        pre_merged_variant = mrg([v1, v2], hn, final_norm=False)
+                                        pre_merged_variant = mrg([v1, v2], hn, final_norm=False, map_dat=map_dat)
                                     else:
-                                        pre_merged_variant = mrg([v2, v1], hn, final_norm=False)
+                                        pre_merged_variant = mrg([v2, v1], hn, final_norm=False, map_dat=map_dat)
                                     if "g" in pre_merged_variant.type:
                                         merged_variant = vm.g_to_n(pre_merged_variant, tx_ac)
                                     else:
@@ -1964,7 +1967,7 @@ def hard_right_hgvs2vcf(hgvs_genomic, primary_assembly, hn, reverse_normalizer, 
     vcf_dict['needs_a_push'] = needs_a_push
     return vcf_dict
 
-def hard_left_hgvs2vcf(hgvs_genomic, primary_assembly, hn, reverse_normalizer, sf, tx_ac, hdp, alt_aln_method,
+def hard_left_hgvs2vcf(hgvs_genomic, primary_assembly, hn, reverse_normalizer, sf, tx_ac, map_dat, alt_aln_method,
                        hp, vm, mrg, genomic_ac=False, mapped_g=False, pre_norm=False ):
     """
     Designed specifically for gap handling.
@@ -1975,7 +1978,7 @@ def hard_left_hgvs2vcf(hgvs_genomic, primary_assembly, hn, reverse_normalizer, s
     :param reverse_normalizer:
     :param sf:
     :param tx_ac:
-    :param hdp:
+    :param map_dat: cached fetcher/store for transcript mapping data
     :param alt_aln_method:
     :param hp:
     :param vm:
@@ -2129,7 +2132,8 @@ def hard_left_hgvs2vcf(hgvs_genomic, primary_assembly, hn, reverse_normalizer, s
         # Set exon boundary
         if genomic_ac is False:
             # Find the boundaries at the genomic level for the current exon
-            exon_set = hdp.get_tx_exons(tx_ac, hgvs_genomic.ac, alt_aln_method)
+            exon_set = map_dat.mapped_exons(
+                    tx_ac, hgvs_genomic.ac, alt_aln_method=alt_aln_method)
             exon_start_genomic = None
             for exon in exon_set:
                 if int(exon[7]) + 1 <= int(pos) <= int(exon[8]):
@@ -2137,7 +2141,8 @@ def hard_left_hgvs2vcf(hgvs_genomic, primary_assembly, hn, reverse_normalizer, s
                     break
         else:
             # Trick the system using transcript positions
-            exon_set = hdp.get_tx_exons(hgvs_genomic.ac, genomic_ac, alt_aln_method)
+            exon_set = map_dat.mapped_exons(
+                    hgvs_genomic.ac, genomic_ac, alt_aln_method=alt_aln_method)
             exon_start_genomic = None
             for exon in exon_set:
                 if int(exon[5]) + 1 <= int(pos) <= int(exon[6]):
@@ -2327,9 +2332,9 @@ def hard_left_hgvs2vcf(hgvs_genomic, primary_assembly, hn, reverse_normalizer, s
                         else:
                             try:
                                 if v1.posedit.pos.start.base < v2.posedit.pos.start.base:
-                                    pre_merged_variant = mrg([v1, v2], reverse_normalizer, final_norm=False)
+                                    pre_merged_variant = mrg([v1, v2], reverse_normalizer, final_norm=False, map_dat=map_dat)
                                 else:
-                                    pre_merged_variant = mrg([v2, v1], reverse_normalizer, final_norm=False)
+                                    pre_merged_variant = mrg([v2, v1], reverse_normalizer, final_norm=False, map_dat=map_dat)
                                 if "g" in pre_merged_variant.type:
                                     merged_variant = vm.g_to_n(pre_merged_variant, tx_ac)
                                 else:
@@ -2553,9 +2558,9 @@ def hard_left_hgvs2vcf(hgvs_genomic, primary_assembly, hn, reverse_normalizer, s
                         else:
                             try:
                                 if v1.posedit.pos.start.base < v2.posedit.pos.start.base:
-                                    pre_merged_variant = mrg([v1, v2], reverse_normalizer, final_norm=False)
+                                    pre_merged_variant = mrg([v1, v2], reverse_normalizer, final_norm=False, map_dat=map_dat)
                                 else:
-                                    pre_merged_variant = mrg([v2, v1], reverse_normalizer, final_norm=False)
+                                    pre_merged_variant = mrg([v2, v1], reverse_normalizer, final_norm=False, map_dat=map_dat)
                                 if "g" in pre_merged_variant.type:
                                     # identifying_g_variant = pre_merged_variant
                                     merged_variant = vm.g_to_n(pre_merged_variant, tx_ac)
@@ -2689,7 +2694,7 @@ def hgvs_ref_alt(hgvs_variant, sf):
 
 def incomplete_alignment_mapping_t_to_g(validator, variant):
     output = None
-    mapping_options = validator.hdp.get_tx_mapping_options(variant.input_parses.ac)
+    mapping_options = variant.map_dat.mapping_options(variant.input_parses.ac,hdp=validator.hdp)
     for option in mapping_options:
         if option[2] == validator.alt_aln_method and "NC_" not in option[1]:
             in_assembly = seq_data.to_chr_num_refseq(option[1], variant.primary_assembly)

--- a/VariantValidator/modules/liftover.py
+++ b/VariantValidator/modules/liftover.py
@@ -16,6 +16,7 @@ from . import utils
 from pyliftover import LiftOver
 import copy
 from VariantValidator.modules.hgvs_utils import hgvs_delins_parts_to_hgvs_obj
+from VariantValidator.modules.transcript_map_data import TranscriptMapData
 
 # Pre compile variables
 vvhgvs.global_config.formatting.max_ref_length = 1000000
@@ -26,7 +27,8 @@ LO_CACHE = {}
 
 def liftover(hgvs_genomic, build_from, build_to, hn, reverse_normalizer, evm, validator,
              specify_tx=False, liftover_level=False, g_to_g=False, gap_map=False, vfo=False,
-             specified_tx_variant=False, genomic_data_w_vcf=False, force_pyliftover=False):
+             specified_tx_variant=False, genomic_data_w_vcf=False, force_pyliftover=False,
+             map_dat = False):
     """
     Step 1, attempt to liftover using a common RefSeq transcript
     Step 2, attempt to liftover using PyLiftover.
@@ -171,13 +173,15 @@ def liftover(hgvs_genomic, build_from, build_to, hn, reverse_normalizer, evm, va
 
     # Try to liftover
     if tx_list is not False and force_pyliftover is False:
+        if not map_dat:
+            map_dat = TranscriptMapData(hdp=validator.hdp)
         selected = []
         # Liftover via a specific tx if it can be done!
         if specify_tx is not False:
             tx_list = [specify_tx]
         for tx in tx_list:
             # identify the first transcript if any
-            options = validator.hdp.get_tx_mapping_options(tx)
+            options = map_dat.mapping_options(tx,hdp=validator.hdp)
             for op in options:
                 sff = None
                 sft = None
@@ -280,11 +284,11 @@ def liftover(hgvs_genomic, build_from, build_to, hn, reverse_normalizer, evm, va
                         else:
                             try:
                                 hgvs_alt_genomic = validator.myvm_t_to_g(specified_tx_variant, hgvs_alt_genomic.ac,
-                                                                         no_norm_evm, hn)
+                                                                         no_norm_evm,hn, map_dat)
                             except AttributeError:
                                 if specified_tx_variant is None:
                                     hgvs_alt_genomic = validator.myvm_t_to_g(hgvs_tx, hgvs_alt_genomic.ac,
-                                                                             no_norm_evm, hn)
+                                                                             no_norm_evm,hn,map_dat)
 
                             if str(check_current_alt_genomic) != str(hgvs_alt_genomic):
                                 am_i_gapped = {"gapped_alignment_warning": f"Variant {utils.valstr(hgvs_alt_genomic)} may "

--- a/VariantValidator/modules/mappers.py
+++ b/VariantValidator/modules/mappers.py
@@ -120,6 +120,22 @@ def gene_to_transcripts(variant, validator, select_transcripts_dict):
         " one or more genes and are currently only described at the genome (g.)"
         " level.")
 
+    # Now handle the loss of relevant variants caused by select_transcripts.
+    # Settings like mane, mane_select, etc can reset rel_var to empty, and we
+    # need to know this before the rel_var empty detection/handling steps.
+    unrestricted_map_found = False
+    if len(rel_var):
+        unrestricted_map_found = True
+        gap_mapper = gapped_mapping.GapMapper(variant, validator)
+        try:
+            var_dat, nw_rel_var = gap_mapper.gapped_g_to_c(rel_var, select_transcripts_dict)
+        except Exception as e:
+            logger.info(f"nw_rel_var creation failed with exception {str(e)}")
+            raise TranscriptMappingError(f"Encountered an issue when mapping genomic description "
+                                         f"{variant.hgvs_formatted} to available transcripts")
+
+        rel_var = nw_rel_var
+
     if len(rel_var) == 0:
         # Check for NG_
         if variant.hgvs_formatted.ac.startswith('NG_'):
@@ -187,6 +203,11 @@ def gene_to_transcripts(variant, validator, select_transcripts_dict):
                         error = (f'None of the specified transcripts ({validator.select_transcripts}) '
                                  f'fully overlap the described variation in '
                                  f'the genomic sequence. Try selecting one of the default options')
+                    elif validator.select_transcripts not in ['raw'] and unrestricted_map_found:
+                        error = ('Transcripts were found but the current transcript type limitation (of '
+                                 f'{validator.select_transcripts}) removed all transcripts that overlap '
+                                 'the described variation in the genomic sequence. You may want to try '
+                                 'selecting less restrictive setting for this variant.')
                     else:
                         error = no_tx_found_error
                     # set output type flag
@@ -208,29 +229,19 @@ def gene_to_transcripts(variant, validator, select_transcripts_dict):
     else:
         # Tag the line so that it is not written out
         variant.write = False
-        gap_mapper = gapped_mapping.GapMapper(variant, validator)
-        try:
-            data, nw_rel_var = gap_mapper.gapped_g_to_c(rel_var, select_transcripts_dict)
-        except Exception as e:
-            logger.info(f"nw_rel_var creation failed with exception {str(e)}")
-            raise TranscriptMappingError(f"Encountered an issue when mapping genomic description "
-                                         f"{variant.hgvs_formatted} to available transcripts")
-
-        rel_var = nw_rel_var
         auto_info_list = []
-        if data["gapped_alignment_warning"] != "":
-            data["auto_info"] = data["auto_info"].replace("NM_", ";NM_")
-            data["auto_info"] = data["auto_info"].replace("NR_", ";NR_")
-            auto_info_list = data["auto_info"].split(";")
-
+        if var_dat["gapped_alignment_warning"] != "":
+            var_dat["auto_info"] = var_dat["auto_info"].replace("NM_", ";NM_")
+            var_dat["auto_info"] = var_dat["auto_info"].replace("NR_", ";NR_")
+            auto_info_list = var_dat["auto_info"].split(";")
         # Set the values and append to batch_list
         for c_description in rel_var:
             # Add gap warnings
             gap_warnings = []
-            if data["gapped_alignment_warning"] != "":
+            if var_dat["gapped_alignment_warning"] != "":
                 for aut_inf in auto_info_list:
                     if c_description.ac in aut_inf:
-                        gap_warnings.append(data["gapped_alignment_warning"])
+                        gap_warnings.append(var_dat["gapped_alignment_warning"])
                         gap_warnings.append(aut_inf)
 
             query = Variant(variant.original, quibble=c_description, warnings=variant.warnings + gap_warnings,

--- a/VariantValidator/modules/mappers.py
+++ b/VariantValidator/modules/mappers.py
@@ -23,7 +23,9 @@ class TranscriptMappingError(Exception):
 def gene_to_transcripts(variant, validator, select_transcripts_dict):
     logger.info(f"Mapping {variant.hgvs_formatted} to transcripts")
     g_query = variant.hgvs_formatted
-
+    # set hdp for exon mapping fetch before first use
+    if not variant.map_dat.hdp:
+        variant.map_dat.hdp = validator.hdp
     # Genomic coordinates can be validated immediately
     error = 'false'
     try:
@@ -77,7 +79,7 @@ def gene_to_transcripts(variant, validator, select_transcripts_dict):
             try:
                 hgvs_coding_variant.rel_ac = ''
                 variant.hgvs_genomic = validator.myevm_t_to_g(hgvs_coding_variant, variant.no_norm_evm,
-                                                              variant.primary_assembly, variant.hn)
+                                                              variant.primary_assembly, variant.hn,variant)
             except vvhgvs.exceptions.HGVSError:
                 try_rel_var = []
             else:
@@ -248,6 +250,8 @@ def gene_to_transcripts(variant, validator, select_transcripts_dict):
                             primary_assembly=variant.primary_assembly, order=variant.order,
                             selected_assembly=variant.selected_assembly, reformat_output=variant.reformat_output,
                             expanded_repeat=variant.expanded_repeat)
+            # since we already fetched the exon mappings etc and python uses just a pointer for this set map_dat
+            query.map_dat = variant.map_dat
             validator.batch_list.append(query)
             logger.info("Submitting new variant with format %s", str(c_description))
 
@@ -298,6 +302,7 @@ def transcripts_to_gene(variant, validator, select_transcripts_dict_plus_version
                 variant.no_norm_evm,
                 variant.primary_assembly,
                 variant.hn,
+                variant,
                 reset_g_origin=reset_g_origin)
         genomic_ac = to_g.ac
 
@@ -319,7 +324,7 @@ def transcripts_to_gene(variant, validator, select_transcripts_dict_plus_version
         if 'does not agree with reference sequence' not in str(e):
             errors.append('Required information for ' + tx_ac + ' is missing from the Universal Transcript Archive')
             errors.append('Query gene2transcripts with search term %s for available transcripts' % tx_ac.split('.')[0])
-        
+
         if 'does not agree with reference sequence' in str(e):
             errors.append(str(e))
         
@@ -400,7 +405,7 @@ def transcripts_to_gene(variant, validator, select_transcripts_dict_plus_version
 
     elif ':g.' in quibble_input:
         if plus.search(formatted_variant) or minus.search(formatted_variant):
-            to_g = validator.genomic(out_hgvs_obj, variant.no_norm_evm, variant.primary_assembly, variant.hn)
+            to_g = validator.genomic(out_hgvs_obj, variant.no_norm_evm, variant.primary_assembly, variant)
             if 'error' in str(to_g):
                 if validator.alt_aln_method != 'genebuild':
                     error = "If the following error message does not address the issue and the problem persists " \
@@ -490,7 +495,7 @@ def transcripts_to_gene(variant, validator, select_transcripts_dict_plus_version
             pre_var = out_hgvs_obj
             try:
                 pre_var = validator.myevm_t_to_g(pre_var, variant.no_norm_evm, variant.primary_assembly,
-                                                 variant.hn)
+                                                 variant.hn,variant)
             except Exception as e:
                 error = str(e)
                 if error == 'expected from_start_i <= from_end_i':
@@ -572,7 +577,7 @@ def transcripts_to_gene(variant, validator, select_transcripts_dict_plus_version
             trans_acc = coding.ac
             # c to Genome coordinates - Map the variant to the genome
             pre_var = validator.genomic(out_hgvs_obj, variant.no_norm_evm, variant.primary_assembly,
-                                        variant.hn)
+                                        variant)
 
             # genome back to C coordinates
             logger.info(f"Attempt to map {pre_var} back to c. coordinates")
@@ -649,7 +654,7 @@ def transcripts_to_gene(variant, validator, select_transcripts_dict_plus_version
     # valid is false if the input contains a \d+\d, \d-\d or :g.
     if not valid:
         genomic_validation = validator.genomic(quibble_input_hgvs_obj, variant.no_norm_evm, variant.primary_assembly,
-                                                   variant.hn)
+                                                   variant)
         if fn.valstr(pre_valid) != fn.valstr(post_valid):
             if variant.reftype != ':g.':
                 if caution == '':
@@ -684,10 +689,8 @@ def transcripts_to_gene(variant, validator, select_transcripts_dict_plus_version
     # Gap compensating code status
     gap_compensation = True
 
-    # Gap gene black list
-    if variant.gene_symbol:
-        # If the gene symbol is not in the list, the value False will be returned
-        gap_compensation = seq_data.gap_black_list(variant.gene_symbol)
+    # If the gene symbol is not in the list, the value False will be returned
+    gap_compensation = variant.map_dat.is_gapped_map(hgvs_coding.ac,genomic_ac,hdp=validator.hdp)
 
     # Intron spanning variants
     if 'boundary' in str(error) or 'spanning' in str(error):
@@ -706,7 +709,8 @@ def transcripts_to_gene(variant, validator, select_transcripts_dict_plus_version
     if variant.hgvs_genomic is not None:
         hgvs_genomic = variant.hgvs_genomic
     else:
-        hgvs_genomic = validator.myevm_t_to_g(hgvs_coding, variant.no_norm_evm, variant.primary_assembly, variant.hn)
+        hgvs_genomic = validator.myevm_t_to_g(hgvs_coding, variant.no_norm_evm, variant.primary_assembly,
+                                              variant.hn,variant)
 
 
 
@@ -717,7 +721,10 @@ def transcripts_to_gene(variant, validator, select_transcripts_dict_plus_version
     # Loop out gap finding code under these circumstances!
     if gap_compensation is True:
         # Get orientation of the gene wrt genome and a list of exons mapped to the genome
-        ori = validator.tx_exons(tx_ac=tx_ac, alt_ac=genomic_ac, alt_aln_method=validator.alt_aln_method)
+        ori = variant.map_dat.tx_exons(
+                tx_ac, genomic_ac,
+                validator.alt_aln_method,
+                hdp=validator.hdp)
         hgvs_genomic, suppress_c_normalization, hgvs_coding = gap_mapper.g_to_t_compensation(ori, hgvs_coding, rec_var)
     else:
         suppress_c_normalization = 'false'
@@ -732,13 +739,15 @@ def transcripts_to_gene(variant, validator, select_transcripts_dict_plus_version
     logger.debug("gap_compensation_2 = " + str(gap_compensation))
     if gap_compensation is True:
         # Get orientation of the gene wrt genome and a list of exons mapped to the genome
-        ori = validator.tx_exons(tx_ac=hgvs_coding.ac, alt_ac=reverse_normalized_hgvs_genomic.ac,
-                                 alt_aln_method=validator.alt_aln_method)
+        ori = variant.map_dat.tx_exons(
+                hgvs_coding.ac, reverse_normalized_hgvs_genomic.ac,
+                validator.alt_aln_method,
+                hdp=validator.hdp)
         hgvs_coding = gap_mapper.g_to_t_gapped_mapping_stage2(ori, hgvs_coding, hgvs_genomic)
 
     # OBTAIN THE RefSeqGene coordinates
     # Attempt 1 = UTA
-    sequences_for_tx = validator.hdp.get_tx_mapping_options(hgvs_coding.ac)
+    sequences_for_tx = variant.map_dat.mapping_options(hgvs_coding.ac)
     recovered_rsg = []
 
     for sequence in sequences_for_tx:
@@ -813,8 +822,10 @@ def transcripts_to_gene(variant, validator, select_transcripts_dict_plus_version
             hgvs_protein = protein_dict['hgvs_protein']
 
     # Gene orientation wrt genome
-    ori = validator.tx_exons(tx_ac=hgvs_coding.ac, alt_ac=hgvs_genomic.ac,
-                             alt_aln_method=validator.alt_aln_method)
+    ori = variant.map_dat.tx_exons(
+            hgvs_coding.ac, hgvs_genomic.ac,
+            validator.alt_aln_method,
+            hdp=validator.hdp)
 
     try:
         ori = int(ori[0]['alt_strand'])
@@ -955,7 +966,6 @@ def transcripts_to_gene(variant, validator, select_transcripts_dict_plus_version
 def final_tx_to_multiple_genomic(variant, validator, tx_variant, liftover_level=False):
     warnings = ''
     rec_var = ''
-    gap_compensation = True
 
     try:
         tx_variant.ac
@@ -963,27 +973,22 @@ def final_tx_to_multiple_genomic(variant, validator, tx_variant, liftover_level=
     except AttributeError:
         variant.hgvs_coding = validator.hp.parse_hgvs_variant(str(tx_variant))
 
-    # Gap gene black list
-    if variant.gene_symbol:
-        # If the gene symbol is not in the list, the value False will be returned
-        gap_compensation = seq_data.gap_black_list(variant.gene_symbol)
-
     # Look for variants spanning introns
+    disable_gap_compensation = False
     try:
         variant.hn.normalize(variant.hgvs_coding)
     except vvhgvs.exceptions.HGVSUnsupportedOperationError as e:
         error = str(e)
         if 'boundary' in error or 'spanning' in error:
-            gap_compensation = False
+            disable_gap_compensation = True
+            logger.debug("gap_compensation_3 disabled due to boundary/spanning")
 
     except vvhgvs.exceptions.HGVSError as e:
         logger.debug("Except passed, %s", e)
 
-    # Warn gap code status
-    logger.debug("gap_compensation_3 = " + str(gap_compensation))
     multi_g = []
     multi_list = []
-    mapping_options = validator.hdp.get_tx_mapping_options(variant.hgvs_coding.ac)
+    mapping_options = variant.map_dat.mapping_options(variant.hgvs_coding.ac,hdp=validator.hdp)
     mapping_options = sorted(mapping_options, key=itemgetter(1))
 
     for alt_chr in mapping_options:
@@ -1006,14 +1011,20 @@ def final_tx_to_multiple_genomic(variant, validator, tx_variant, liftover_level=
                 continue
         try:
             # Re set ori
-            ori = validator.tx_exons(tx_ac=variant.hgvs_coding.ac, alt_ac=alt_chr,
-                                     alt_aln_method=validator.alt_aln_method)
+            ori = variant.map_dat.tx_exons(
+                    variant.hgvs_coding.ac, alt_chr,
+                    validator.alt_aln_method,
+                    hdp=validator.hdp)
 
             # Map the variant to the genome
-            hgvs_alt_genomic = validator.myvm_t_to_g(variant.hgvs_coding, alt_chr, variant.no_norm_evm, variant.hn)
+            hgvs_alt_genomic = validator.myvm_t_to_g(variant.hgvs_coding, alt_chr, variant.no_norm_evm,
+                                                     variant.hn, variant.map_dat)
 
             # Loop out gap code under these circumstances!
-            if gap_compensation:
+            if variant.map_dat.is_gapped_map(variant.hgvs_coding.ac,hgvs_alt_genomic.ac,validator):
+                # warn on gap_compensation for
+                logger.debug("gap_compensation_3 done for %s when mapped to %s" %
+                             (variant.hgvs_coding.ac, hgvs_alt_genomic.ac))
                 gap_mapper = gapped_mapping.GapMapper(variant, validator)
                 hgvs_alt_genomic, hgvs_coding = gap_mapper.g_to_t_gap_compensation_version3(
                     hgvs_alt_genomic, variant.hgvs_coding, ori, alt_chr, rec_var)
@@ -1024,7 +1035,8 @@ def final_tx_to_multiple_genomic(variant, validator, tx_variant, liftover_level=
                         hgvs_alt_genomic.posedit.edit.type != 'delins':
                     try:
                         rev_tx = variant.reverse_normalizer.normalize(hgvs_coding)
-                        rev_g = validator.myvm_t_to_g(rev_tx, alt_chr, variant.no_norm_evm, variant.hn)
+                        rev_g = validator.myvm_t_to_g(rev_tx, alt_chr, variant.no_norm_evm,
+                                                      variant.hn, variant.map_dat)
                         rev_g = variant.hn.normalize(rev_g)
                     except vvhgvs.exceptions.HGVSError:
                         rev_g = hgvs_alt_genomic
@@ -1039,7 +1051,8 @@ def final_tx_to_multiple_genomic(variant, validator, tx_variant, liftover_level=
                         "ins" not in hgvs_alt_genomic.posedit.edit.type:
                     try:
                         rev_tx = variant.reverse_normalizer.normalize(variant.hgvs_coding)
-                        rev_g = validator.myvm_t_to_g(rev_tx, alt_chr, variant.no_norm_evm, variant.hn)
+                        rev_g = validator.myvm_t_to_g(rev_tx, alt_chr, variant.no_norm_evm,
+                                                      variant.hn, variant.map_dat)
                         rev_g = variant.hn.normalize(rev_g)
                     except vvhgvs.exceptions.HGVSError:
                         rev_g = hgvs_alt_genomic

--- a/VariantValidator/modules/mappers.py
+++ b/VariantValidator/modules/mappers.py
@@ -8,6 +8,7 @@ from .variant import Variant
 from . import seq_data
 from . import utils as fn
 from . import gapped_mapping
+from .gapped_mapping import immediate_round_trip_gap_ins_handling
 from operator import itemgetter
 from VariantValidator.modules.hgvs_utils import hgvs_delins_parts_to_hgvs_obj,\
         unset_hgvs_obj_ref
@@ -725,6 +726,13 @@ def transcripts_to_gene(variant, validator, select_transcripts_dict_plus_version
                 tx_ac, genomic_ac,
                 validator.alt_aln_method,
                 hdp=validator.hdp)
+        if hgvs_coding.posedit.edit.type == 'ins':
+            new_hgvs_coding, new_hgvs_genomic = immediate_round_trip_gap_ins_handling(
+                    hgvs_coding, hgvs_genomic,variant)
+            if str(new_hgvs_coding) != str(hgvs_coding):
+                hgvs_coding = new_hgvs_coding
+            if str(new_hgvs_genomic) != str(hgvs_genomic):
+                hgvs_genomic = new_hgvs_genomic
         hgvs_genomic, suppress_c_normalization, hgvs_coding = gap_mapper.g_to_t_compensation(ori, hgvs_coding, rec_var)
     else:
         suppress_c_normalization = 'false'
@@ -743,7 +751,16 @@ def transcripts_to_gene(variant, validator, select_transcripts_dict_plus_version
                 hgvs_coding.ac, reverse_normalized_hgvs_genomic.ac,
                 validator.alt_aln_method,
                 hdp=validator.hdp)
-        hgvs_coding = gap_mapper.g_to_t_gapped_mapping_stage2(ori, hgvs_coding, hgvs_genomic)
+
+        if not hgvs_genomic.posedit.edit.type == 'ins':
+            hgvs_coding = gap_mapper.g_to_t_gapped_mapping_stage2(ori, hgvs_coding, hgvs_genomic)
+        else:
+            new_hgvs_coding, new_hgvs_genomic = immediate_round_trip_gap_ins_handling(
+                    hgvs_coding, hgvs_genomic,variant)
+            if str(new_hgvs_coding) != str(hgvs_coding):
+                hgvs_coding = new_hgvs_coding
+            hgvs_genomic = new_hgvs_genomic
+
 
     # OBTAIN THE RefSeqGene coordinates
     # Attempt 1 = UTA

--- a/VariantValidator/modules/transcript_map_data.py
+++ b/VariantValidator/modules/transcript_map_data.py
@@ -1,0 +1,163 @@
+import copy
+"""
+A module for holding the TranscriptMapData specific to an individual transcript
+in order to avoid having to repeatedly re-pull from the database.
+"""
+class TranscriptMapData():
+    """
+    This object is used to hold the transcript mapping data used in all tx
+    variants, but in a way that does not force VariantFormatter to pull in the
+    whole VV variant object. We may add more such functions later to reduce the
+    amount sundry transcript mapping objects passed around in bits.
+    """
+    def __init__(self,hdp=None):
+        """
+        Initialisation of TranscriptMapData object, can keep the last validator
+        hgvs data provider, to avoid constantly having to re-specify or pass
+        around the validator separately.
+        """
+        self.hdp = hdp # current validator hgvs data provider in use
+        self.mapping_opts = {} # used to only fetch once from vv/uta per tx
+        self.gap_status = {} # made using above map data, for dict fetch
+        self.mapped_strands = {} # made using above map data, for dict fetch
+        self.mapping_types = {} # the mapping type for each tx->alt map
+        self.exon_data = {} # the set of exon data per mapping
+
+    def mapping_options(self,tx_ac,hdp=None):
+        """
+        Get mapping options for the main variant transcript.
+
+        These were originally fetched repeatedly from the database, this
+        function centralises the fetch and caches the first result, it can't
+        change without a server restart anyway.
+        """
+        if tx_ac in self.mapping_opts:
+            return self.mapping_opts[tx_ac]
+        if hdp:
+            cur_hdp = hdp
+            self.hdp = hdp
+        elif self.hdp:
+            cur_hdp = self.hdp
+        else:
+            raise ValueError(
+                    "Either the creation, or the first data fetch, of each"
+                    "TranscriptMapData object must specify a hgvs data "
+                    "provider (hdp) for use as a data source")
+        self.mapping_opts[tx_ac] = cur_hdp.get_tx_mapping_options(
+                tx_ac,gap_warn=True)
+        return self.mapping_opts[tx_ac]
+
+    def map_strand(self,tx_ac,alt_ac,hdp=None):
+        """
+        Return the strand for a transcript, as mapped to a specific alt
+        accession to allow strand fetch without exon fetch, or repeated
+        database queries.
+        """
+        if tx_ac in self.mapped_strands:
+            if alt_ac in self.mapped_strands[tx_ac]:
+                return self.mapped_strands[tx_ac][alt_ac]
+            return False
+        map_opts = self.mapping_options(tx_ac,hdp)
+        # opts layout is tx_ac,alt_ac,alt_aln_method, gapped, strand
+        for opt in map_opts:
+            if not opt[0] in self.mapped_strands:
+                self.mapped_strands[opt[0]] = {}
+            self.mapped_strands[opt[0]][opt[1]] = opt[4]
+
+        if alt_ac in self.mapped_strands[tx_ac]:
+            return self.mapped_strands[tx_ac][alt_ac]
+        return False
+
+    def is_gapped_map(self,tx_ac,alt_ac,hdp=None):
+        """
+        Returns true if the mapping in question is gapped, otherwise false.
+        Allows us to do without the fixed bad gene list (which also impacts
+        un-gapped mappings of problem transcripts.
+        """
+        if tx_ac in self.gap_status:
+            if alt_ac in self.gap_status[tx_ac] \
+                    and self.gap_status[tx_ac][alt_ac]:
+                return True
+            return False
+        self.gap_status[tx_ac] = {}
+        map_opts = self.mapping_options(tx_ac,hdp)
+        for opt in map_opts:
+            self.gap_status[tx_ac][opt[1]] = opt[3]
+        if alt_ac in self.gap_status[tx_ac]:
+            return self.gap_status[tx_ac][alt_ac]
+        return False
+
+    def map_type(self,tx_ac,alt_ac,hdp=None):
+        """
+        Look up the map type of the requested tx->alt ac pair, prefer not blat
+        """
+        if tx_ac in self.mapping_types:
+            if alt_ac not in self.mapping_types[tx_ac]:
+                return []
+            return self.mapping_types[tx_ac][alt_ac]
+        self.mapping_types[tx_ac] = {}
+        map_opts = self.mapping_options(tx_ac,hdp)
+        for opt in map_opts:
+            if opt[2] == 'blat' and opt[1] in self.mapping_types[tx_ac]:
+                continue
+            self.mapping_types[tx_ac][opt[1]] = opt[2]
+        if alt_ac not in self.mapping_types[tx_ac]:
+            return False
+        return self.mapping_types[tx_ac][alt_ac]
+
+    def mapped_exons(self,tx_ac,alt_ac,alt_aln_method=None,hdp=None):
+        """
+        Return exon set data for mapping in question, without repeated db fetch.
+        This version just returns the cached results in the same order as
+        fetched, and presumes that the data is not edited on use in problematic
+        ways.
+        """
+        if hdp:
+            cur_hdp = hdp
+            self.hdp = hdp
+        elif self.hdp:
+            cur_hdp = self.hdp
+        else:
+            raise ValueError(
+                    "Either the creation, or the first data fetch, of each"
+                    "TranscriptMapData object must specify a hgvs data "
+                    "provider (hdp) for use as a data source")
+        if tx_ac not in self.exon_data:
+            self.exon_data[tx_ac] = {}
+        if alt_ac not in self.exon_data[tx_ac]:
+            if alt_aln_method:
+                aln_method = alt_aln_method
+            else:
+                aln_method = self.map_type(tx_ac,alt_ac)
+            self.exon_data[tx_ac][alt_ac] = cur_hdp.get_tx_exons(
+                    tx_ac,alt_ac,aln_method)
+        if alt_ac not in self.exon_data[tx_ac]:
+            return []
+        return self.exon_data[tx_ac][alt_ac]
+
+    def tx_exons(self, tx_ac, alt_ac, alt_aln_method, hdp=None):
+        """
+        Alt strand flipped exon data function, cached version of orig validator
+        function, some users of this method seem to edit this data.
+        Returns exon information for a given transcript
+        e.g. how the exons align to the genomic reference
+        see vvhgvs.dataproviders.uta.py for details
+        """
+        # Interface with the UTA database via get_tx_exons in uta.py
+        tx_exons = self.mapped_exons(
+                tx_ac, alt_ac,
+                hdp=hdp,
+                alt_aln_method=alt_aln_method)
+        tx_exons = copy.copy(tx_exons)
+        try:
+            tx_exons[0]['alt_strand']
+        except TypeError:
+            tx_exons = 'error'
+            return tx_exons
+        # If on the reverse strand, reverse the order of elements
+        if tx_exons[0]['alt_strand'] == -1:
+            tx_exons = tx_exons[::-1]
+            return tx_exons
+        else:
+            return tx_exons
+

--- a/VariantValidator/modules/use_checking.py
+++ b/VariantValidator/modules/use_checking.py
@@ -367,7 +367,7 @@ def structure_checks(variant, validator):
                 if variant.input_parses.posedit.pos.end.offset != 0:
                     variant.input_parses.posedit.pos.end.offset =1
                 hgvs_genomic_vt = validator.myevm_t_to_g(variant.input_parses, variant.no_norm_evm,
-                                                         variant.primary_assembly, variant.hn)
+                                                         variant.primary_assembly, variant.hn, variant)
                 format_converters.remap_intronic(variant.input_parses, hgvs_genomic_vt, variant, validator)
             return True
 
@@ -545,7 +545,7 @@ def structure_checks_c(variant, validator):
                                                                                  prevalidation_level=None)
 
                             report_gen = validator.myevm_t_to_g(variant.input_parses, variant.no_norm_evm,
-                                                                variant.primary_assembly, variant.hn)
+                                                                variant.primary_assembly, variant.hn, variant)
                             report_gen = variant.hn.normalize(report_gen)
                             error = 'Using a transcript reference sequence to specify a variant position that lies ' \
                                     'outside of the reference sequence is not HGVS-compliant: ' \
@@ -569,7 +569,7 @@ def structure_checks_c(variant, validator):
             error = 'Using a transcript reference sequence to specify a variant position that lies outside of the ' \
                     'reference sequence is not HGVS-compliant. Instead re-submit '
             genomic_position = validator.myevm_t_to_g(input_parses, variant.no_norm_evm, variant.primary_assembly,
-                                                      variant.hn)
+                                                      variant.hn, variant)
             genomic_position = variant.hn.normalize(genomic_position)
             error = error + fn.valstr(genomic_position)
             variant.warnings.append(error)
@@ -584,7 +584,7 @@ def structure_checks_c(variant, validator):
             # Can we go c-g-c
             try:
                 to_genome = validator.myevm_t_to_g(variant.input_parses, variant.no_norm_evm,
-                                                   variant.primary_assembly, variant.hn)
+                                                   variant.primary_assembly, variant.hn, variant)
                 to_tx = variant.evm.g_to_t(to_genome, variant.input_parses.ac)
             except vvhgvs.exceptions.HGVSInvalidIntervalError as e:
                 error = str(e)
@@ -625,7 +625,7 @@ def structure_checks_c(variant, validator):
                             variant.input_parses.posedit.pos.end.offset = offset
 
                         report_gen = validator.myevm_t_to_g(variant.input_parses, variant.no_norm_evm,
-                                                            variant.primary_assembly, variant.hn)
+                                                            variant.primary_assembly, variant.hn, variant)
                         report_gen = variant.hn.normalize(report_gen)
                         error = 'Using a transcript reference sequence to specify a variant position that lies ' \
                                 'outside of the reference sequence is not HGVS-compliant. Instead re-submit '\
@@ -669,7 +669,7 @@ def structure_checks_c(variant, validator):
             if 'bounds' in error:
                 try:
                     report_gen = validator.myevm_t_to_g(variant.input_parses, variant.no_norm_evm,
-                                                        variant.primary_assembly, variant.hn)
+                                                        variant.primary_assembly, variant.hn, variant)
                     report_gen = variant.hn.normalize(report_gen)
                 except vvhgvs.exceptions.HGVSError as e:
                     logger.debug("Except passed, %s", e)
@@ -888,7 +888,7 @@ def structure_checks_n(variant, validator):
                         variant.input_parses.posedit.pos.end.base = boundary
                         variant.input_parses.posedit.pos.end.offset = remainder
                     report_gen = validator.myevm_t_to_g(variant.input_parses, variant.no_norm_evm,
-                                                        variant.primary_assembly, variant.hn)
+                                                        variant.primary_assembly, variant.hn, variant)
                     report_gen = variant.hn.normalize(report_gen)
                     error = 'Using a transcript reference sequence to specify a variant position that lies outside of' \
                             ' the reference sequence is not HGVS-compliant. Instead re-submit ' + fn.valstr(report_gen)
@@ -906,7 +906,7 @@ def structure_checks_n(variant, validator):
         error = 'Using a transcript reference sequence to specify a variant position that lies outside of the ' \
                 'reference sequence is not HGVS-compliant. Instead re-submit '
         genomic_position = validator.myevm_t_to_g(variant.input_parses, variant.no_norm_evm, variant.primary_assembly,
-                                                  variant.hn)
+                                                  variant.hn,variant)
         genomic_position = variant.hn.normalize(genomic_position)
         error = error + fn.valstr(genomic_position)
         variant.warnings.append(error)
@@ -922,7 +922,7 @@ def structure_checks_n(variant, validator):
             if 'bounds' in error:
                 try:
                     report_gen = validator.myevm_t_to_g(variant.input_parses, variant.no_norm_evm,
-                                                        variant.primary_assembly, variant.hn)
+                                                        variant.primary_assembly, variant.hn,variant)
                     report_gen = variant.hn.normalize(report_gen)
                 except vvhgvs.exceptions.HGVSError as e:
                     logger.debug("Except passed, %s", e)
@@ -951,13 +951,13 @@ def structure_checks_n(variant, validator):
             elif 'Cannot validate sequence of an intronic variant' in error:
                 try:
                     test_g = validator.myevm_t_to_g(variant.input_parses, variant.no_norm_evm, variant.primary_assembly,
-                                                    variant.hn)
+                                                    variant.hn,variant)
                     variant.evm.g_to_t(test_g, variant.input_parses.ac)
                 except vvhgvs.exceptions.HGVSError as e:
                     error = str(e)
                     if 'bounds' in error:
                         report_gen = validator.myevm_t_to_g(variant.input_parses, variant.no_norm_evm,
-                                                            variant.primary_assembly, variant.hn)
+                                                            variant.primary_assembly, variant.hn,variant)
                         report_gen = variant.hn.normalize(report_gen)
                         error = 'Using a transcript reference sequence to specify a variant position that lies ' \
                                 'outside of the reference sequence is not HGVS-compliant. Instead re-submit ' + \

--- a/VariantValidator/modules/utils.py
+++ b/VariantValidator/modules/utils.py
@@ -36,7 +36,19 @@ PROT_TRANSLATION_DICT = {
 PROT_TRANSLATION_DICT_SEL = copy.copy(PROT_TRANSLATION_DICT)
 PROT_TRANSLATION_DICT_SEL['TGA'] = 'U'
 
+DNA_TRANS_TBL = str.maketrans("ACTG", "TGAC")
 
+def simple_dna_revcomp(dna):
+    """
+    Simplest possible reverse compliment, for use on validated input and
+    DNA (or cDNA) of known origin.
+
+    Multiple online published performance benchmarks put this method at
+    the top of the performance comparison for simple DNA reverse
+    compliment, VS loop based and dict lookup among others.
+    Biopython does(did?) the same internally, but adds extra checks.
+    """
+    return dna.upper().translate(DNA_TRANS_TBL)[::-1]
 
 def handleCursor(func):
     """

--- a/VariantValidator/modules/utils.py
+++ b/VariantValidator/modules/utils.py
@@ -619,7 +619,7 @@ def get_exon_boundary_list(variant, validator):
     transcript = variant.quibble.split(':')[0]
     if transcript.startswith('NM_' or 'NR_' or 'ENST'):
         # Get alignment options and identify the relevant primary assembly chrom
-        mapping_options = validator.hdp.get_tx_mapping_options(transcript)
+        mapping_options = variant.map_dat.mapping_options(transcript,hdp=validator.hdp)
         chromosome_reference = None
         for option in mapping_options:
             is_in_assembly = seq_data.to_chr_num_refseq(option[1], variant.primary_assembly)
@@ -643,7 +643,10 @@ def get_exon_boundary_list(variant, validator):
             cds_end = 0
 
         # Get the exon boundaries of the transcript
-        exons = validator.hdp.get_tx_exons(transcript, chromosome_reference, validator.alt_aln_method)
+        exons = variant.map_dat.mapped_exons(
+                transcript, chromosome_reference,
+                alt_aln_method=validator.alt_aln_method,
+                hdp=validator.hdp)
 
         # Extract the exon boundaries
         exon_boundaries = []

--- a/VariantValidator/modules/variant.py
+++ b/VariantValidator/modules/variant.py
@@ -1,6 +1,6 @@
 import re
 from . import utils as fn
-
+from .transcript_map_data import TranscriptMapData
 
 class Variant(object):
     """
@@ -63,6 +63,7 @@ class Variant(object):
         self.min_evm = None
         self.lose_vm = None
         self.no_replace_vm = None
+        self.map_dat = TranscriptMapData()
 
         # Required for output
         self.stable_gene_ids = None
@@ -79,6 +80,7 @@ class Variant(object):
         self.validated = False
         self.exonic_positions = None
         self.rna_data = None
+
 
     def is_ascii(self):
         """

--- a/VariantValidator/modules/vvMixinConverters.py
+++ b/VariantValidator/modules/vvMixinConverters.py
@@ -2,6 +2,7 @@ import re
 import copy
 import logging
 import vvhgvs
+from vvhgvs.assemblymapper import AssemblyMapper
 import vvhgvs.validator
 from . import vvMixinInit
 from . import seq_data
@@ -18,6 +19,8 @@ from vvhgvs.exceptions import HGVSError, HGVSDataNotAvailableError, HGVSUnsuppor
 from vvhgvs.enums import Datum # needed to handle r->n mapping without re-parsing posedit
 from VariantValidator.modules.hgvs_utils import hgvs_delins_parts_to_hgvs_obj, hgvs_dup_to_delins,\
         hgvs_obj_from_existing_edit
+from VariantValidator.modules.transcript_map_data import TranscriptMapData
+
 logger = logging.getLogger(__name__)
 
 class AlleleSyntaxError(Exception):
@@ -60,12 +63,13 @@ class Mixin(vvMixinInit.Mixin):
         elif variant.type == 'c':
             return variant
 
-    def genomic(self, variant, evm, primary_assembly, hn):
+    def genomic(self, variant, evm, primary_assembly, vv_variant):
         """
         Mapping transcript to genomic position
         Ensures variants are transcript c. or n.
         returns parsed hgvs g. object
         """
+        hn = vv_variant.hn
         logger.info(f"Map {variant} to genomic position")
         logger.info(f"Primary assembly: {primary_assembly}")
         # If the :c. pattern is present in the input variant
@@ -73,7 +77,7 @@ class Mixin(vvMixinInit.Mixin):
             logger.info(f"Variant {variant} is not a string")
             if variant.type in ['c','n']:
                 try:
-                    var_g = self.myevm_t_to_g(variant, evm, primary_assembly, hn)
+                    var_g = self.myevm_t_to_g(variant, evm, primary_assembly, hn, vv_variant)
                 except vvhgvs.exceptions.HGVSError as e:
                     logger.info(f"HGVS error: {e}")
                 logger.info(f"Variant {variant} mapped to {var_g}")
@@ -83,7 +87,7 @@ class Mixin(vvMixinInit.Mixin):
         elif ':c.' in variant or ':n.' in variant:
             hgvs_var = self.hp.parse_hgvs_variant(variant)
             try:
-                var_g = self.myevm_t_to_g(hgvs_var, evm, primary_assembly, hn)  # genomic level variant
+                var_g = self.myevm_t_to_g(hgvs_var, evm, primary_assembly, hn, vv_variant)  # genomic level variant
             except vvhgvs.exceptions.HGVSError as e:
                 return 'error ' + str(e)
             return var_g
@@ -94,7 +98,7 @@ class Mixin(vvMixinInit.Mixin):
             var_g = self.hp.parse_hgvs_variant(variant)
             return var_g
 
-    def myevm_t_to_g(self, hgvs_c, no_norm_evm, primary_assembly, hn, reset_g_origin=False):
+    def myevm_t_to_g(self, hgvs_c, no_norm_evm, primary_assembly, hn, variant, reset_g_origin=False):
         """
         Enhanced transcript to genome position mapping function using evm
         If reset_g_origin is false keeps the original mapping source, otherwise re-sets
@@ -117,45 +121,30 @@ class Mixin(vvMixinInit.Mixin):
         stored_hgvs_c = copy.deepcopy(hgvs_c)
         expand_out = False
 
-        # Gap gene black list
-        try:
-            gene_symbol = self.db.get_gene_symbol_from_transcript_id(hgvs_c.ac)         
-
-        except Exception:
-            utilise_gap_code = False
-
-        else:
-            # If the gene symbol is not in the list, the value False will be returned
-            utilise_gap_code = seq_data.gap_black_list(gene_symbol)
-
-        # Warn gap code in use
-        logger.debug("gap_compensation_myevm = " + str(utilise_gap_code))
-
-        if utilise_gap_code is True and hgvs_c.posedit.edit.type in [
-                'identity', 'del', 'delins', 'dup', 'sub', 'ins', 'inv']:
+        def gap_pre_tx_corrections(hgvs_cg):
+            if hgvs_cg.posedit.edit.type not in [
+                    'identity', 'del', 'delins', 'dup', 'sub', 'ins', 'inv']:
+                return hgvs_cg
             # if NM_ need the n. position
-            if hgvs_c.type == "c":
-                hgvs_c = no_norm_evm.c_to_n(hgvs_c)
+            if hgvs_cg.type == "c":
+                hgvs_cg = no_norm_evm.c_to_n(hgvs_cg)
 
             # Check for intronic
             try:
-                hn.normalize(hgvs_c)
+                hn.normalize(hgvs_cg)
             except vvhgvs.exceptions.HGVSError as e:
                 error = str(e)
                 if 'intronic variant' not in error and \
                         'Length implied by coordinates must equal sequence deletion length' in error and \
-                        hgvs_c.ac.startswith('NR_'):
-                    hgvs_c.posedit.pos.end.base = hgvs_c.posedit.pos.start.base + len(hgvs_c.posedit.edit.ref) - 1
+                        hgvs_cg.ac.startswith('NR_'):
+                    hgvs_cg.posedit.pos.end.base = hgvs_c.posedit.pos.start.base + len(hgvs_c.posedit.edit.ref) - 1
 
             # Check again before continuing
-            if re.search(r'\d+\+', str(hgvs_c.posedit.pos)) or re.search(r'\d+-', str(hgvs_c.posedit.pos)) or \
-                    re.search(r'\*\d+\+', str(hgvs_c.posedit.pos)) or re.search(r'\*\d+-', str(hgvs_c.posedit.pos)):
-                pass
-
-            else:
+            if not(hgvs_cg.posedit.pos.start.offset or hgvs_cg.posedit.pos.end.offset):
+                pre_spread_hgvs_cg = hgvs_cg
                 try:
                     # For non-intronic sequence
-                    hgvs_t = copy.deepcopy(hgvs_c)
+                    hgvs_t = copy.deepcopy(hgvs_cg)
                     if hgvs_t.posedit.edit.type == 'inv':
                         inv_alt = self.revcomp(hgvs_t.posedit.edit.ref)
                         pre_base, post_base = seld._expand_ref(
@@ -170,7 +159,7 @@ class Mixin(vvMixinInit.Mixin):
                                 pre_base + inv_alt + post_base,
                                 end=hgvs_t.posedit.pos.end.base +1,
                                 offset_pos=True)
-                    elif hgvs_c.posedit.edit.type == 'dup':
+                    elif hgvs_cg.posedit.edit.type == 'dup':
                         pre_base, post_base = self._expand_ref(
                                 str(hgvs_t.ac),
                                 hgvs_t.posedit.pos.start.base - 2,
@@ -182,7 +171,7 @@ class Mixin(vvMixinInit.Mixin):
                                 pre_base + hgvs_t.posedit.edit.ref + post_base,
                                 pre_base + hgvs_t.posedit.edit.ref + hgvs_t.posedit.edit.ref + post_base,
                                 offset_pos=True)
-                    elif hgvs_c.posedit.edit.type == 'ins':
+                    elif hgvs_cg.posedit.edit.type == 'ins':
                         # ins->delins goes from between coordinates, i.e exclusive to inclusive so
                         # adjust coordinates to match (or rather don't) by 1 base
                         ins_ref = self.sf.fetch_seq(str(hgvs_t.ac), hgvs_t.posedit.pos.start.base - 2,
@@ -209,136 +198,164 @@ class Mixin(vvMixinInit.Mixin):
                                 pre_base + hgvs_t.posedit.edit.alt + post_base,
                                 end=hgvs_t.posedit.pos.end.base + 1,
                                 offset_pos=True)
-                    hgvs_c = copy.deepcopy(hgvs_t)
+                    hgvs_cg = copy.deepcopy(hgvs_t)
 
                     # Set expanded out test to true
                     expand_out = True
 
                 except Exception:
-                    hgvs_c = hgvs_c
-
+                    hgvs_cg = hgvs_cg
             # Convert back to c. from n. position.
             try:
-                hgvs_c = no_norm_evm.n_to_c(hgvs_c)
+                hgvs_cg = no_norm_evm.n_to_c(hgvs_cg)
             except vvhgvs.exceptions.HGVSError:
-                hgvs_c = copy.deepcopy(stored_hgvs_c)
+                hgvs_cg = copy.deepcopy(stored_hgvs_c)
 
             # Ensure the altered c. variant has not crossed intro exon boundaries
-            hgvs_check_boundaries = copy.deepcopy(hgvs_c)
+            hgvs_check_boundaries = copy.deepcopy(hgvs_cg)
             try:
                 hn.normalize(hgvs_check_boundaries)
             except vvhgvs.exceptions.HGVSError as e:
                 error = str(e)
                 if 'spanning the exon-intron boundary' in error:
-                    hgvs_c = copy.deepcopy(stored_hgvs_c)
+                    hgvs_cg = copy.deepcopy(stored_hgvs_c)
             # Catch identity at the exon/intron boundary by trying to normalize ref only
             if hgvs_check_boundaries.posedit.edit.type == 'identity':
                 hgvs_reform_ident = hgvs_delins_parts_to_hgvs_obj(
-                        hgvs_c.ac,
+                        hgvs_cg.ac,
                         stored_hgvs_c.type,
-                        hgvs_c.posedit.pos,hgvs_c.posedit.edit.ref,'',
+                        hgvs_cg.posedit.pos,hgvs_cg.posedit.edit.ref,'',
                         offset_pos=True)
                 try:
                     hn.normalize(hgvs_reform_ident)
                 except vvhgvs.exceptions.HGVSError as e:
                     error = str(e)
                     if 'spanning the exon-intron boundary' in error or 'Normalization of intronic variants' in error:
-                        hgvs_c = copy.deepcopy(stored_hgvs_c)
+                        hgvs_cg = copy.deepcopy(stored_hgvs_c)
+            return hgvs_cg
 
         # Capture errors from attempted mappings
         attempted_mapping_error = ''
         hgvs_genomic = None
-
+        mapping_options = variant.map_dat.mapping_options(hgvs_c.ac,hdp=self.hdp)
+        gap_corrected_hgvs_c = False
+        if reset_g_origin or not hgvs_c.rel_ac:
+            hgvs_c.rel_ac = ''
+            new_targets = []
+            for option in mapping_options:
+                opt_ac = str(option[1])
+                if opt_ac.startswith("NC_"):
+                    new_targets.append(opt_ac)
+            if new_targets:
+                for g_ac in new_targets:
+                    if seq_data.supported_for_mapping(g_ac, primary_assembly):
+                        hgvs_c.rel_ac = g_ac
         try:
-            if reset_g_origin:
-                hgvs_c.rel_ac = ''
-            hgvs_genomic = no_norm_evm.t_to_g(hgvs_c)
-            hn.normalize(hgvs_genomic)  # Check the validity of the mapping
+            hn.normalize(hgvs_c)
+        except:
+            pass
 
+        # previous code had a hidden feature of falling back to last attempted genomic map in the case or
+        # failed normalisation, now make this explicit, sticking to the most preferred mapping instead
+        # we don't currently do more (eg we could prefer any non gapped aln over gapped etc)
+        norm_f_hgvs_genomic = None
+        if hgvs_c.rel_ac:
             # This will fail on multiple refs for NC_ if the origin is not already set!
             # if the origin is set then this keeps the relative genomic origin, which can include NG_ or alts!
-        except vvhgvs.exceptions.HGVSError:
-            # Recover all available mapping options from UTA
-
-            mapping_options = self.hdp.get_tx_mapping_options(hgvs_c.ac)
-
-            if not mapping_options:
-                raise HGVSDataNotAvailableError(
+            try:
+                # Gap map detection, if the tx->chr map is not in the list, False will be returned
+                if variant.map_dat.is_gapped_map(hgvs_c.ac,hgvs_c.rel_ac,hdp=self.hdp):
+                    logger.debug("gap_compensation_myevm enabled for %s against %s" % (hgvs_c.ac, hgvs_c.rel_ac))
+                    gap_corrected_hgvs_c = gap_pre_tx_corrections(hgvs_c)
+                    hgvs_genomic = no_norm_evm.t_to_g(gap_corrected_hgvs_c)
+                else:
+                    hgvs_genomic = no_norm_evm.t_to_g(hgvs_c)
+                hn.normalize(hgvs_genomic)  # Check the validity of the mapping
+            except vvhgvs.exceptions.HGVSError:
+                # Take all available mapping options from UTA and check through them
+                norm_f_hgvs_genomic = hgvs_genomic
+                hgvs_genomic = None
+                if not mapping_options:
+                    raise HGVSDataNotAvailableError(
                     "No alignment data between the specified transcript reference sequence and any GRCh37 and GRCh38 "
                     "genomic reference sequences (including alternate chromosome assemblies, patches and RefSeqGenes) "
                     "are available.")
-
-            def search_through_options(hgvs_genomic, seqtype, chr_num_val, alt_aln_method=None, final=False):
-
-                err = ''
-                for option in mapping_options:
-                    if option[2].startswith('blat'):
-                        continue
-                    if option[1].startswith(seqtype):
-                        chr_num = seq_data.supported_for_mapping(str(option[1]), primary_assembly)
-
-                        if final or (chr_num_val and chr_num is False) or (chr_num_val is False and chr_num is False):
-                            try:
-                                
-                                hgvs_genomic = self.vm.t_to_g(hgvs_c, str(option[1]), alt_aln_method)
-                                break
-                            except Exception as e:
-                                err += str(e) + "/" + hgvs_c.ac + "/" + option[1] + '~'
-                                continue
-
-                return hgvs_genomic, err
-
-            hgvs_genomic, new_error = search_through_options(hgvs_genomic, 'NC_', True, alt_aln_method)
-            attempted_mapping_error += new_error
-
-            # If not mapped, raise error
-            try:
-                hn.normalize(hgvs_genomic)
-            except:
-                hgvs_genomic, new_error = search_through_options(hgvs_genomic, 'NC_', False, alt_aln_method)
-                attempted_mapping_error += new_error
-
-                try:
-                    hn.normalize(hgvs_genomic)
-                except:
-                    hgvs_genomic, new_error = search_through_options(hgvs_genomic, 'NT_', True, alt_aln_method)
-                    attempted_mapping_error += new_error
-
-                    try:
-                        hn.normalize(hgvs_genomic)
-                    except:
-                        hgvs_genomic, new_error = search_through_options(hgvs_genomic, 'NT_', False, alt_aln_method)
-                        attempted_mapping_error += new_error
-
+        err = ''
+        for genomic_ac_type in ['NC_','NT_','NW_','NG_']:
+            if hgvs_genomic:
+                break
+            # need to call parent t_to_g on this or we fail due to opt number
+            cur_opts = []
+            for option in mapping_options:
+                opt_ac = str(option[1])
+                if str(option[2]).startswith('blat') or not opt_ac.startswith(genomic_ac_type):
+                    continue
+                cur_opts.append(opt_ac)
+            if not genomic_ac_type == 'NG_': # NG not chromosomal so never check chr num
+                for opt in cur_opts:
+                    if seq_data.supported_for_mapping(opt, primary_assembly):
+                        try:
+                            if variant.map_dat.is_gapped_map(hgvs_c.ac,opt,hdp=self.hdp):
+                                logger.debug("gap_compensation_myevm enabled for %s against %s")
+                                if not gap_corrected_hgvs_c:
+                                    gap_corrected_hgvs_c = gap_pre_tx_corrections(hgvs_c)
+                                hgvs_genomic = super(AssemblyMapper,no_norm_evm).t_to_g(
+                                        gap_corrected_hgvs_c, opt, alt_aln_method=alt_aln_method)
+                            else:
+                                hgvs_genomic = super(AssemblyMapper,no_norm_evm).t_to_g(
+                                        hgvs_c, str(option[1]), alt_aln_method=alt_aln_method)
+                        except Exception as e:
+                            err += str(e) + "/" + hgvs_c.ac + "/" + option[1] + '~'
+                    if hgvs_genomic:
                         try:
                             hn.normalize(hgvs_genomic)
-                        except:
-                            hgvs_genomic, new_error = search_through_options(hgvs_genomic, 'NW_', True, alt_aln_method)
-                            attempted_mapping_error += new_error
+                        except Exception:
+                            if not norm_f_hgvs_genomic:
+                                norm_f_hgvs_genomic = hgvs_genomic
+                            hgvs_genomic = None
+            if hgvs_genomic:
+                break
+            for opt in cur_opts:
+                # don't repeat if it already tested and failed
+                if seq_data.supported_for_mapping(opt, primary_assembly):
+                    continue
+                try:
+                    if variant.map_dat.is_gapped_map(hgvs_c.ac,opt,hdp=self.hdp):
+                        logger.debug("gap_compensation_myevm enabled for %s against %s")
+                        if not gap_corrected_hgvs_c:
+                            gap_corrected_hgvs_c = gap_pre_tx_corrections(hgvs_c)
+                        hgvs_genomic = super(AssemblyMapper,no_norm_evm).t_to_g(
+                            gap_corrected_hgvs_c, opt, alt_aln_method=alt_aln_method)
+                    else:
+                        hgvs_genomic = super(AssemblyMapper,no_norm_evm).t_to_g(
+                                hgvs_c, opt, alt_aln_method=alt_aln_method)
+                except Exception as e:
+                    err += str(e) + "/" + hgvs_c.ac + "/" + option[1] + '~'
+                if hgvs_genomic:
+                    try:
+                        hn.normalize(hgvs_genomic)
+                    except Exception:
+                        if not norm_f_hgvs_genomic:
+                            norm_f_hgvs_genomic = hgvs_genomic
+                        hgvs_genomic = None
 
-                            try:
-                                hn.normalize(hgvs_genomic)
-                            except:
-                                hgvs_genomic, new_error = search_through_options(hgvs_genomic, 'NW_', False, alt_aln_method)
-                                attempted_mapping_error += new_error
-
-                                # Only a RefSeqGene available
-                                try:
-                                    hn.normalize(hgvs_genomic)
-                                except:
-                                    hgvs_genomic, new_error = search_through_options(hgvs_genomic, 'NG_', True, alt_aln_method,
-                                                                                     final=True)
-                                    attempted_mapping_error += new_error
+        attempted_mapping_error = err
+        if ( not hgvs_genomic ) and norm_f_hgvs_genomic:
+            hgvs_genomic = norm_f_hgvs_genomic
 
         # If not mapped, raise error
         if hgvs_genomic is None:
             logger.debug("HGVS data not avaialable error")
             raise HGVSDataNotAvailableError(attempted_mapping_error)
 
+        # we expand out for variants that are not intronic and are gapped
+        expand_out = variant.map_dat.is_gapped_map(hgvs_c.ac,hgvs_genomic.ac,hdp=self.hdp) and not(
+                hgvs_c.posedit.pos.start.offset or hgvs_c.posedit.pos.end.offset)
         if hgvs_c.posedit.edit.type == 'identity' and hgvs_genomic.posedit.edit.type == 'delins' and \
                 hgvs_genomic.posedit.edit.alt == '' and not expand_out:
             hgvs_genomic.posedit.edit.alt = hgvs_genomic.posedit.edit.ref
-        if hgvs_genomic.posedit.edit.type == 'ins' and utilise_gap_code is True:
+        if hgvs_genomic.posedit.edit.type == 'ins' and variant.map_dat.is_gapped_map(
+                hgvs_c.ac,hgvs_genomic.ac,hdp=self.hdp):
             try:
                 hgvs_genomic = hn.normalize(hgvs_genomic)
             except vvhgvs.exceptions.HGVSError as e:
@@ -474,8 +491,8 @@ class Mixin(vvMixinInit.Mixin):
                         # Remove alt
                         try:
                             genomic_gap_variant.posedit.edit.alt = ''
-                        except Exception as e:
-                            logger.debug("Except passed, %s", e)
+                        except Exception as er:
+                            logger.debug("Except passed, %s", er)
 
                         # Should be a delins so will normalize statically and replace the reference bases
                         genomic_gap_variant = hn.normalize(genomic_gap_variant)
@@ -503,8 +520,8 @@ class Mixin(vvMixinInit.Mixin):
                                 transcript_gap_alt_n.posedit.edit.alt = 'X'
                         except Exception as e:
                             if str(e) == "'Dup' object has no attribute 'alt'":
-                                transcript_gap_n_delins_from_dup = hgvs_dup_to_delins(transcript_gap_n)
-                                transcript_gap_alt_n_delins_from_dup = hgvs_dup_to_delins(transcript_gap_alt_n)
+                                transcript_gap_n = hgvs_dup_to_delins(transcript_gap_n)
+                                transcript_gap_alt_n = hgvs_dup_to_delins(transcript_gap_alt_n)
 
                         # Split the reference and replacing alt sequence into a dictionary
                         reference_bases = list(transcript_gap_n.posedit.edit.ref)
@@ -590,7 +607,8 @@ class Mixin(vvMixinInit.Mixin):
         # Remove identity bases
         if hgvs_c == stored_hgvs_c:
             pass
-        elif expand_out is False or utilise_gap_code is False:
+        elif expand_out is False or variant.map_dat.is_gapped_map(
+                hgvs_c.ac,hgvs_c.rel_ac,hdp=self.hdp) is False:
             pass
         # Correct expansion ref + 2
         elif expand_out and (
@@ -774,7 +792,7 @@ class Mixin(vvMixinInit.Mixin):
         # This will fail on multiple refs for NC_
         except vvhgvs.exceptions.HGVSError:
             # Recover all available mapping options from UTA
-            mapping_options = self.hdp.get_tx_mapping_options(hgvs_c.ac)
+            mapping_options = variant.map_dat.mapping_options(hgvs_c.ac,hdp=self.hdp)
 
             if not mapping_options:
                 raise HGVSDataNotAvailableError("no g. mapping options available")
@@ -898,20 +916,12 @@ class Mixin(vvMixinInit.Mixin):
         hgvs_t = evm.g_to_t(hgvs_genomic, alt_ac)
         return hgvs_t
 
-    def myvm_t_to_g(self, hgvs_c, alt_chr, no_norm_evm, hn):
+    def myvm_t_to_g(self, hgvs_c, alt_chr, no_norm_evm, hn, map_dat):
         # store the input
         alt_aln_method = self.alt_aln_method
         stored_hgvs_c = copy.deepcopy(hgvs_c)
         expand_out = False
-
-        # Gap gene black list
-        try:
-            gene_symbol = self.db.get_gene_symbol_from_transcript_id(hgvs_c.ac)
-        except Exception:
-            utilise_gap_code = False
-        else:
-            # If the gene symbol is not in the list, the value False will be returned
-            utilise_gap_code = seq_data.gap_black_list(gene_symbol)
+        utilise_gap_code = map_dat.is_gapped_map(hgvs_c.ac, alt_chr,hdp=self.hdp)
         # Warn gap code in use
         logger.debug("gap_compensation_mvm = " + str(utilise_gap_code))
 
@@ -1503,29 +1513,6 @@ class Mixin(vvMixinInit.Mixin):
             hgvs_object.posedit.pos.end.datum = Datum.CDS_START
         return hgvs_object
 
-    def tx_exons(self, tx_ac, alt_ac, alt_aln_method):
-        """
-        Returns exon information for a given transcript
-        e.g. how the exons align to the genomic reference
-        see vvhgvs.dataproviders.uta.py for details
-        """
-        # Interface with the UTA database via get_tx_exons in uta.py
-        try:
-            tx_exons = self.hdp.get_tx_exons(tx_ac, alt_ac, alt_aln_method)
-        except vvhgvs.exceptions.HGVSError as e:
-            tx_exons = 'hgvs Exception: ' + str(e)
-            return tx_exons
-        try:
-            tx_exons[0]['alt_strand']
-        except TypeError:
-            tx_exons = 'error'
-            return tx_exons
-        # If on the reverse strand, reverse the order of elements
-        if tx_exons[0]['alt_strand'] == -1:
-            tx_exons = tx_exons[::-1]
-            return tx_exons
-        else:
-            return tx_exons
 
     def relevant_transcripts(self, hgvs_genomic, evm, alt_aln_method, reverse_normalizer, select_transcripts):
         """
@@ -1539,10 +1526,14 @@ class Mixin(vvMixinInit.Mixin):
 
         rts_dict = {}
         for tx_dat in rts_list:
-            rts_dict[tx_dat[0]] = True
-        rts_list_2 = evm.relevant_transcripts(hgvs_genomic)
+            rts_dict[tx_dat['tx_ac']] = tx_dat['alt_strand']
+        rts_list_2 = self.hdp.get_tx_for_region(
+                hgvs_genomic.ac, self.alt_aln_method,
+                hgvs_genomic.posedit.pos.start.base,
+                hgvs_genomic.posedit.pos.end.base)
+        #rts_list_2 = evm.relevant_transcripts(hgvs_genomic)
         for tx_dat_2 in rts_list_2:
-            rts_dict[tx_dat_2] = True
+            rts_dict[tx_dat_2['tx_ac']] = tx_dat['alt_strand']
         rts = list(rts_dict.keys())
 
         # Filter out transcripts that are not the latest versions
@@ -1635,29 +1626,8 @@ class Mixin(vvMixinInit.Mixin):
             if '+' in str(variant) or '-' in str(variant) or '*' in str(variant):
                 tx_ac = variant.ac
                 alt_ac = hgvs_genomic.ac
-
-                # Interface with the UTA database via get_tx_exons in uta.py
                 try:
-                    tx_exons = self.hdp.get_tx_exons(tx_ac, alt_ac, alt_aln_method)
-                except vvhgvs.exceptions.HGVSError:
-                    continue
-                try:
-                    tx_exons[0]['alt_strand']
-                except TypeError:
-                    continue
-                # If on the reverse strand, reverse the order of elements
-                if tx_exons[0]['alt_strand'] == -1:
-                    tx_exons = tx_exons[::-1]
-
-                # Gene orientation
-                if tx_exons[0]['alt_strand'] == -1:
-                    antisense = True
-                else:
-                    antisense = False
-
-                # Pass if antisense = 'false'
-                try:
-                    if antisense:
+                    if rts_dict[tx_ac] < 0:
                         # Reverse normalize hgvs_genomic
                         rev_hgvs_genomic = reverse_normalizer.normalize(hgvs_genomic)
                         # map back to coding
@@ -1738,7 +1708,7 @@ class Mixin(vvMixinInit.Mixin):
         revcomp = revcomp[::-1]
         return revcomp
 
-    def merge_hgvs_3pr(self, hgvs_variant_list, hn, genomic_reference=False, final_norm=True, hgvs_strict=False):
+    def merge_hgvs_3pr(self, hgvs_variant_list, hn, genomic_reference=False, final_norm=True, hgvs_strict=False, map_dat=None):
         """
         Function designed to merge multiple HGVS variants (hgvs objects) into a single delins
         using 3 prime normalization
@@ -1751,6 +1721,10 @@ class Mixin(vvMixinInit.Mixin):
         c_to_g_mapped = {"mapped": False, "ori": None, "transcript": None}
 
         # Sanity check and format the submitted variants
+        # First get a cached exon fetch, this is normally == for all variants submitted
+        tx_map_dat = map_dat
+        if not tx_map_dat:
+            tx_map_dat = TranscriptMapData(hdp=self.hdp)
         for hgvs_v in hgvs_variant_list:
             # For testing include parser
             if type(hgvs_v) is str:
@@ -1767,10 +1741,10 @@ class Mixin(vvMixinInit.Mixin):
                 if 'Cannot validate sequence of an intronic variant' in str(e):
                     if genomic_reference is not False:
                         c_to_g_mapped["mapped"] = True
-                        c_to_g_mapped["ori"] = self.hdp.get_tx_exons(hgvs_v.ac,
-                                                                     genomic_reference,
-                                                                     self.alt_aln_method
-                                                                     )[0][3]
+                        c_to_g_mapped["ori"] = tx_map_dat.mapped_exons(
+                                hgvs_v.ac,
+                                genomic_reference,
+                                alt_aln_method=self.alt_aln_method)[0][3]
                         c_to_g_mapped["transcript"] = hgvs_v.ac
                     else:
                         raise fn.mergeHGVSerror("AlleleSyntaxError: Intronic variants can only be validated if a "

--- a/VariantValidator/modules/vvMixinConverters.py
+++ b/VariantValidator/modules/vvMixinConverters.py
@@ -17,11 +17,13 @@ import json
 from vvhgvs.exceptions import HGVSError, HGVSDataNotAvailableError, HGVSUnsupportedOperationError, \
      HGVSInvalidVariantError
 from vvhgvs.enums import Datum # needed to handle r->n mapping without re-parsing posedit
+from  VariantValidator.modules.utils import simple_dna_revcomp
 from VariantValidator.modules.hgvs_utils import hgvs_delins_parts_to_hgvs_obj, hgvs_dup_to_delins,\
         hgvs_obj_from_existing_edit
 from VariantValidator.modules.transcript_map_data import TranscriptMapData
 
 logger = logging.getLogger(__name__)
+
 
 class AlleleSyntaxError(Exception):
     pass
@@ -610,6 +612,10 @@ class Mixin(vvMixinInit.Mixin):
         elif expand_out is False or variant.map_dat.is_gapped_map(
                 hgvs_c.ac,hgvs_c.rel_ac,hdp=self.hdp) is False:
             pass
+        # correct entirely inside gap
+        elif expand_out and hgvs_genomic.posedit.edit.ref is None:
+            if hgvs_genomic.posedit.edit.alt is not None and len(hgvs_genomic.posedit.edit.alt) > 2:
+                hgvs_genomic.posedit.edit.alt = hgvs_genomic.posedit.edit.alt[1:-1]
         # Correct expansion ref + 2
         elif expand_out and (
                 len(hgvs_genomic.posedit.edit.ref) == (len(stored_hgvs_c.posedit.edit.ref) + 2)):  # >= 3:
@@ -766,6 +772,53 @@ class Mixin(vvMixinInit.Mixin):
                         hgvs_genomic = no_norm_evm.t_to_g(hgvs_c)
                     except Exception as e:
                         error = str(e)
+
+        # finally handle bad non gapped handling of dup and inv, due to no alt seq stored by hgvs
+        # only affects non-gapped non-intronic miss-match
+        if  hgvs_c.posedit.edit.type in ['dup','inv'] and not variant.map_dat.is_gapped_map(
+                hgvs_c.ac,hgvs_genomic.ac,hdp=self.hdp) and not(
+                        hgvs_c.posedit.pos.start.offset or hgvs_c.posedit.pos.end.offset):
+            if hgvs_c.posedit.edit.ref:
+                old_gen_ref = str(hgvs_c.posedit.edit.ref)
+            else:
+                # normalise re-fills ref if empty
+                try:
+                    hn.normalize(hgvs_c)
+                    old_gen_ref = str(hgvs_c.posedit.edit.ref)
+                except Exception as e:
+                    if hgvs_c.type == 'c':
+                        fix_n = self.vm.c_to_n(hgvs_c)
+                    else:
+                        fix_n = hgvs_c
+                    old_gen_ref = self.sf.fetch_seq(str(fix_n.ac), fix_n.posedit.pos.start.base - 1,
+                                               fix_n.posedit.pos.end.base)
+            strand = 1
+            for option in mapping_options:
+                if str(option[1]) == hgvs_genomic.ac:
+                    strand = int(option[4])
+
+            if strand == -1:
+                old_gen_ref = simple_dna_revcomp(old_gen_ref)
+            # check vs input var ref and create indel if needed
+            if not old_gen_ref == hgvs_genomic.posedit.edit.ref:
+                if hgvs_c.posedit.edit.type == 'dup':
+                    hgvs_genomic = hgvs_delins_parts_to_hgvs_obj(
+                        hgvs_genomic.ac,
+                        hgvs_genomic.type,
+                        hgvs_genomic.posedit.pos,hgvs_genomic.posedit.edit.ref,old_gen_ref+old_gen_ref,
+                        offset_pos=True)
+                else:
+                    hgvs_genomic = hgvs_delins_parts_to_hgvs_obj(
+                        hgvs_genomic.ac,
+                        hgvs_genomic.type,
+                        hgvs_genomic.posedit.pos,hgvs_genomic.posedit.edit.ref,
+                        simple_dna_revcomp(old_gen_ref),
+                        offset_pos=True)
+                # normalise down (e.g.dup->delins->ins)
+                try:
+                    hn.normalize(hgvs_genomic)
+                except:
+                    pass
 
         return hgvs_genomic
 
@@ -1043,7 +1096,14 @@ class Mixin(vvMixinInit.Mixin):
             hgvs_genomic.posedit.edit.alt = hgvs_genomic.posedit.edit.ref
         if hgvs_genomic.posedit.edit.type == 'ins' and utilise_gap_code is True:
             try:
+                pre_norm_genomic = copy.copy(hgvs_genomic)# can move ins variants (and in doing so break mid base == original bases assumption)
                 hgvs_genomic = hn.normalize(hgvs_genomic)
+                if stored_hgvs_c.posedit.edit.alt and len(stored_hgvs_c.posedit.edit.alt) + 2 == \
+                        len(hgvs_c.posedit.edit.alt) and hgvs_c.posedit.edit.alt == pre_norm_genomic.posedit.edit.alt:
+                    pre_norm_genomic.posedit.edit.alt = pre_norm_genomic.posedit.edit.alt[1:-1]
+                    hgvs_genomic = copy.copy(pre_norm_genomic)
+                    hgvs_genomic = hn.normalize(hgvs_genomic)
+                    hgvs_c.posedit.edit.alt = hgvs_c.posedit.edit.alt[1:-1]
             except vvhgvs.exceptions.HGVSError as e:
                 error = str(e)
                 if error == 'insertion length must be 1':
@@ -1069,14 +1129,6 @@ class Mixin(vvMixinInit.Mixin):
                                            stored_hgvs_n.posedit.pos.end.base)
             stored_hgvs_c.posedit.edit.ref = stored_ref
 
-        if (hgvs_genomic.posedit.edit.ref == '' or hgvs_genomic.posedit.edit.ref is None) and expand_out:
-            if hgvs_genomic.posedit.edit.type == 'ins':
-                stored_ref = self.sf.fetch_seq(str(hgvs_genomic.ac), hgvs_genomic.posedit.pos.start.base - 1,
-                                               hgvs_genomic.posedit.pos.end.base)
-                stored_alt = stored_ref[:1] + hgvs_genomic.posedit.edit.alt + stored_ref[-1:]
-                hgvs_genomic.posedit.edit.ref = stored_ref
-                hgvs_genomic.posedit.edit.alt = stored_alt
-
         # First look for variants mapping to the flanks of gaps
         # either in the gap or on the flank but not fully within the gap
         if expand_out:
@@ -1087,8 +1139,8 @@ class Mixin(vvMixinInit.Mixin):
                 error_type_1 = str(e)
                 if 'Length implied by coordinates must equal sequence deletion length' in str(e) or str(
                         e) == 'base start position must be <= end position':
-                    # Effectively, this code is designed to handle variants that are directly proximal to
-                    # gap BOUNDARIES, but in some cases the replace reference function of hgvs mapping has removed bases
+                    # This code is designed use the fact that no-replace mappings don't adjust length to match the span to
+                    # detect, and if needed handle, variants that are directly proximal to gap BOUNDARIES,
                     # due to the deletion length being > the specified range.
                     genomic_gap_variant = None
                     # Warn of variant location wrt the gap
@@ -1110,8 +1162,23 @@ class Mixin(vvMixinInit.Mixin):
                                 genomic_gap_variant = make_gen_var
                                 error_type_1 = None
                         else:
-                            genomic_gap_variant = self.nr_vm.t_to_g(hgvs_c, hgvs_genomic.ac,
-                                                                    alt_aln_method=alt_aln_method)
+                            if genomic_gap_variant.posedit.edit.ref is None and \
+                                    'Length implied by coordinates must equal' in error_type_1:
+                                # handle gaps correctly for current expectations
+                                # with delGCTinsGGT when tx GCT maps to gen GT output should be:
+                                # delG, not C>G, when normalised out
+                                make_gen_var = copy.copy(nr_genomic)
+                                make_gen_var.posedit.edit.ref = self.sf.fetch_seq(
+                                    nr_genomic.ac,
+                                    nr_genomic.posedit.pos.start.base - 1,
+                                    nr_genomic.posedit.pos.end.base
+                                )
+                                genomic_gap_variant = make_gen_var
+                                error_type_1 = None
+                            else:
+                                genomic_gap_variant = self.nr_vm.t_to_g(
+                                        hgvs_c, hgvs_genomic.ac,
+                                        alt_aln_method=alt_aln_method)
 
                     if error_type_1 == 'base start position must be <= end position':
                         logger.info('Variant is fully within a genomic gap')
@@ -1284,6 +1351,7 @@ class Mixin(vvMixinInit.Mixin):
 
                         try:
                             hgvs_genomic = self.vm.t_to_g(transcript_gap_variant, hgvs_genomic.ac, alt_aln_method)
+                            pre_norm_genomic = copy.copy(hgvs_genomic)
                             hgvs_genomic = hn.normalize(hgvs_genomic)
                         except Exception as e:
                             if str(e) == "base start position must be <= end position":
@@ -1305,6 +1373,7 @@ class Mixin(vvMixinInit.Mixin):
                                 except:
                                     transcript_gap_variant = transcript_gap_n
                                 hgvs_genomic = self.vm.t_to_g(transcript_gap_variant, hgvs_genomic.ac, alt_aln_method)
+                                pre_norm_genomic = copy.copy(hgvs_genomic)
                                 hgvs_genomic = hn.normalize(hgvs_genomic)
 
                         # Bypass the next bit of gap code
@@ -1316,6 +1385,17 @@ class Mixin(vvMixinInit.Mixin):
             expand_out = False
         elif expand_out is False or utilise_gap_code is False:
             pass
+        # correct ref inside gap
+        elif expand_out and hgvs_genomic.posedit.edit.ref is None:
+            # inserted entirely inside a gap in the genomic sequence, un-fatten by added flanking bases
+            # this prevents us from spreading the input variant
+            if hgvs_genomic.posedit.edit.alt is not None and len(hgvs_genomic.posedit.edit.alt) > 2:
+                hgvs_genomic = pre_norm_genomic
+                hgvs_genomic.posedit.edit.alt = hgvs_genomic.posedit.edit.alt[1:-1]
+                try:
+                    hgvs_genomic = hn.normalize(hgvs_genomic)
+                except:
+                    pass
         # Correct expansion ref + 2
         elif expand_out and (
                 len(hgvs_genomic.posedit.edit.ref) == (len(stored_hgvs_c.posedit.edit.ref) + 2)):  # >= 3:

--- a/VariantValidator/modules/vvMixinCore.py
+++ b/VariantValidator/modules/vvMixinCore.py
@@ -1289,6 +1289,7 @@ class Mixin(vvMixinConverters.Mixin):
                                                            build_to, variant.hn, variant.reverse_normalizer,
                                                            variant.evm,
                                                            self,
+                                                           map_dat=variant.map_dat,
                                                            specify_tx=False,
                                                            liftover_level=liftover_level,
                                                            g_to_g=g_to_g,

--- a/VariantValidator/modules/vvMixinCore.py
+++ b/VariantValidator/modules/vvMixinCore.py
@@ -1322,35 +1322,10 @@ class Mixin(vvMixinConverters.Mixin):
                             for build_key, accession_dict in list(lifted_response.items()):
                                 try:
                                     accession_key = list(accession_dict.keys())[0]
-                                    for k, v in accession_dict.items():
-                                        hgvs = v["hgvs_genomic_description"].posedit
-                                        edit = hgvs.edit
-
-                                        # Extract HGVS coordinates and edit type (do NOT mutate)
-                                        start = int(hgvs.pos.start.base)
-                                        end = int(hgvs.pos.end.base)
-                                        variant_type = edit.type  # 'del', 'dup', 'inv'
-
-                                        # Only apply SV-style formatting for large variants
-                                        if (variant_type in ["del", "dup", "inv"]
-                                                and len(edit.ref) >= 50):
-
-                                            # Overwrite/standardise VCF-style fields if still needed
-                                            v["vcf"]["pos"] = str(start)  # VCF left anchor convention
-                                            v["vcf"]["ref"] = str(end)
-                                            v["vcf"]["alt"] = variant_type.upper()
-
-                                        else:
-                                            # Small variants: keep original VCF-style representation
-                                            # (no SV transformation)
-                                            pass
-
-
                                     if accession_dict[accession_key]['hgvs_genomic_description'].ac.startswith('NC_'):
                                         primary_assembly_loci[build_key.lower()] = accession_dict[accession_key]
                                     else:
                                         alt_genomic_loci.append({build_key.lower(): accession_dict[accession_key]})
-
                                 # KeyError if the dicts are empty
                                 except KeyError:
                                     continue
@@ -1609,12 +1584,39 @@ class Mixin(vvMixinConverters.Mixin):
                 else:
                     variant.hgvs_refseqgene_variant = ''
                 hgd = "hgvs_genomic_description"
+                def _vcf_abrv(hgvs,vcf,max_non_abrv_len=100):
+                    """
+                    Abbreviate long del/dup/ins type vcf
+                    Use start-stop as pos ref N alt as type,
+                    not pos as start ref and alt as (extra long seq"""
+                    try:
+                        # only shorten vcf if ref based and long
+                        # (and not uncertain which should not have vcf data)
+                        if hgvs.posedit.edit.type not in ["del", "dup", "inv"] or \
+                                len(hgvs.posedit.edit.ref) <= max_non_abrv_len or \
+                                hgvs.posedit.uncertain or hgvs.posedit.pos.uncertain:
+                            return vcf
+                    except AttributeError:
+                        # hgvs can still be text, not object, for some ambig pos, and MT, data
+                        return vcf
+                    # Overwrite/standardise VCF-style fields if still needed
+                    vcf["pos"] = f'{str(hgvs.posedit.pos.start.base)}-{str(hgvs.posedit.pos.end.base)}'
+                    vcf["ref"] = 'N'
+                    vcf["alt"] = hgvs.posedit.edit.type.upper()
+                    return vcf
 
                 for gen in variant.primary_assembly_loci.keys():
+                    variant.primary_assembly_loci[gen]['vcf'] = _vcf_abrv(
+                            variant.primary_assembly_loci[gen][hgd],
+                            variant.primary_assembly_loci[gen]['vcf'])
                     variant.primary_assembly_loci[gen][hgd] = \
                         variant.primary_assembly_loci[gen][hgd].format({'max_ref_length': 0})
+
                 for loc in variant.alt_genomic_loci:
                     for gen in loc.keys():
+                        loc[gen]['vcf'] = _vcf_abrv(
+                            loc[gen][hgd],
+                            loc[gen]['vcf'])
                         loc[gen][hgd] = loc[gen][hgd].format({'max_ref_length': 0})
 
                 # Append to a list for return

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -1169,21 +1169,13 @@ class TestVariantsAuto(TestCase):
         assert results['NM_000518.4:c.316_*100del']['hgvs_lrg_variant'] == ''
         self.assertCountEqual(results['NM_000518.4:c.316_*100del']['alt_genomic_loci'], [])
         assert results['NM_000518.4:c.316_*100del']['primary_assembly_loci']['hg19'] == {
-            'hgvs_genomic_description': 'NC_000011.9:g.5246728_5246956del', 'vcf': {'chr': 'chr11', 'pos': '5246727',
-                                                                                    'ref': 'AATCCAGATGCTCAAGGCCCTTCATAATATCCCCCAGTTTAGTAGTTGGACTTAGGGAACAAAGGAACCTTTAATAGAAATTGGACAGCAAGAAAGCGAGCTTAGTGATACTTGTGGGCCAGGGCATTAGCCACACCAGCCACCACTTTCTGATAGGCAGCCTGCACTGGTGGGGTGAATTCTTTGCCAAAGTGATGGGCCAGCACACAGACCAGCACGTTGCCCAGGAG',
-                                                                                    'alt': 'A'}}
+            'hgvs_genomic_description': 'NC_000011.9:g.5246728_5246956del', 'vcf': {'alt': 'DEL', 'chr': 'chr11', 'pos': '5246728-5246956', 'ref': 'N'}}
         assert results['NM_000518.4:c.316_*100del']['primary_assembly_loci']['hg38'] == {
-            'hgvs_genomic_description': 'NC_000011.10:g.5225498_5225726del', 'vcf': {'chr': 'chr11', 'pos': '5225497',
-                                                                                     'ref': 'AATCCAGATGCTCAAGGCCCTTCATAATATCCCCCAGTTTAGTAGTTGGACTTAGGGAACAAAGGAACCTTTAATAGAAATTGGACAGCAAGAAAGCGAGCTTAGTGATACTTGTGGGCCAGGGCATTAGCCACACCAGCCACCACTTTCTGATAGGCAGCCTGCACTGGTGGGGTGAATTCTTTGCCAAAGTGATGGGCCAGCACACAGACCAGCACGTTGCCCAGGAG',
-                                                                                     'alt': 'A'}}
+            'hgvs_genomic_description': 'NC_000011.10:g.5225498_5225726del', 'vcf': {'alt': 'DEL', 'chr': 'chr11', 'pos': '5225498-5225726', 'ref': 'N'}}
         assert results['NM_000518.4:c.316_*100del']['primary_assembly_loci']['grch37'] == {
-            'hgvs_genomic_description': 'NC_000011.9:g.5246728_5246956del', 'vcf': {'chr': '11', 'pos': '5246727',
-                                                                                    'ref': 'AATCCAGATGCTCAAGGCCCTTCATAATATCCCCCAGTTTAGTAGTTGGACTTAGGGAACAAAGGAACCTTTAATAGAAATTGGACAGCAAGAAAGCGAGCTTAGTGATACTTGTGGGCCAGGGCATTAGCCACACCAGCCACCACTTTCTGATAGGCAGCCTGCACTGGTGGGGTGAATTCTTTGCCAAAGTGATGGGCCAGCACACAGACCAGCACGTTGCCCAGGAG',
-                                                                                    'alt': 'A'}}
+            'hgvs_genomic_description': 'NC_000011.9:g.5246728_5246956del', 'vcf': {'alt': 'DEL', 'chr': '11', 'pos': '5246728-5246956', 'ref': 'N'}}
         assert results['NM_000518.4:c.316_*100del']['primary_assembly_loci']['grch38'] == {
-            'hgvs_genomic_description': 'NC_000011.10:g.5225498_5225726del', 'vcf': {'chr': '11', 'pos': '5225497',
-                                                                                     'ref': 'AATCCAGATGCTCAAGGCCCTTCATAATATCCCCCAGTTTAGTAGTTGGACTTAGGGAACAAAGGAACCTTTAATAGAAATTGGACAGCAAGAAAGCGAGCTTAGTGATACTTGTGGGCCAGGGCATTAGCCACACCAGCCACCACTTTCTGATAGGCAGCCTGCACTGGTGGGGTGAATTCTTTGCCAAAGTGATGGGCCAGCACACAGACCAGCACGTTGCCCAGGAG',
-                                                                                     'alt': 'A'}}
+            'hgvs_genomic_description': 'NC_000011.10:g.5225498_5225726del', 'vcf': {'alt': 'DEL', 'chr': '11', 'pos': '5225498-5225726', 'ref': 'N'}}
         assert results['NM_000518.4:c.316_*100del']['reference_sequence_records'] == {
             'transcript': 'https://www.ncbi.nlm.nih.gov/nuccore/NM_000518.4',
             'protein': 'https://www.ncbi.nlm.nih.gov/nuccore/NP_000509.1',
@@ -30367,17 +30359,13 @@ class TestVariantsAuto(TestCase):
                    'hgvs_lrg_transcript_variant'] == 'LRG_128t1:c.588_589insCTACATAG'
         assert results['NM_000061.2:c.588_589insCTACATAG']['hgvs_lrg_variant'] == ''
         self.assertCountEqual(results['NM_000061.2:c.588_589insCTACATAG']['alt_genomic_loci'], [])
-        assert results['NM_000061.2:c.588_589insCTACATAG']['primary_assembly_loci']['hg19'] == {
-            'hgvs_genomic_description': 'NC_000023.10:g.100615752_100617160del',
-            'vcf': {'chr': 'chrX', 'pos': '100615752',
-                                                                                         'ref': '100617160',
-                                                                                         'alt': 'DEL'}}
-        # # assert 'hg38' not in list(results['NM_000061.2:c.588_589insCTACATAG']['primary_assembly_loci'].keys())
-        assert results['NM_000061.2:c.588_589insCTACATAG']['primary_assembly_loci']['grch37'] == {
-            'hgvs_genomic_description': 'NC_000023.10:g.100615752_100617160del', 'vcf': {'chr': 'X', 'pos': '100615752',
-                                                                                         'ref': '100617160',
-                                                                                         'alt': 'DEL'}}
-        # assert 'grch38' not in list(results['NM_000061.2:c.588_589insCTACATAG']['primary_assembly_loci'].keys())
+
+        assert results['NM_000061.2:c.588_589insCTACATAG']['primary_assembly_loci']['hg19']['hgvs_genomic_description'] == 'NC_000023.10:g.100615752_100617160del'
+        assert results['NM_000061.2:c.588_589insCTACATAG']['primary_assembly_loci']['grch37']['hgvs_genomic_description'] == 'NC_000023.10:g.100615752_100617160del'
+
+        assert results['NM_000061.2:c.588_589insCTACATAG']['primary_assembly_loci']['grch37']['vcf'] == {'chr': 'X', 'pos': '100615752-100617160','ref': 'N', 'alt': 'DEL'}
+        assert results['NM_000061.2:c.588_589insCTACATAG']['primary_assembly_loci']['hg19']['vcf'] == {'chr': 'chrX', 'pos': '100615752-100617160','ref': 'N','alt': 'DEL'}
+
         assert results['NM_000061.2:c.588_589insCTACATAG']['reference_sequence_records'] == {
             'transcript': 'https://www.ncbi.nlm.nih.gov/nuccore/NM_000061.2',
             'protein': 'https://www.ncbi.nlm.nih.gov/nuccore/NP_000052.1'}

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -30978,13 +30978,26 @@ class TestVariantsAuto(TestCase):
                results['NM_005228.5:c.2309_2310delinsCCAGCGTGGAT']['hgvs_predicted_protein_consequence']['slr']
 
     def test_issue_dup_to_gen_delins(self):
+        # the handling of this issue has changed with the addition of improved gap detection, as NM_178172.2
+        # is a non-gapped transcript in a gap gene.
+        # the underlying variant here is gcgggcgg -> gcgggcgggcgg Where the first base is != GRCh38 (A!=G)
+        # When gap handling triggered we got 45_48dup -> 41_44dup and this caused delins output
+        # test old and new! Also TODO liftover ins should be of initial ins wrt ref, not ref bases (A).
         variant = 'NM_178172.2:c.45_48dup'
         results = self.vv.validate(variant, 'GRCh38', 'all').format_as_dict(test=True)
         print(results)
-        assert 'NC_000008.11:g.143213308delinsGCGGG' in \
+        assert '143213312_143213315dup' in \
                results['NM_178172.2:c.45_48dup']['primary_assembly_loci']['grch38']['hgvs_genomic_description']
-        assert 'NC_000008.10:g.144295187_144295190dup' in \
+        assert 'NC_000008.10:g.144295182_144295183insTCGG' in \
                results['NM_178172.2:c.45_48dup']['primary_assembly_loci']['grch37']['hgvs_genomic_description']
+        # has actual gap will trigger gap code along with dup->ins conversion
+        variant = 'NM_178172.4:c.41_44dup'
+        results = self.vv.validate(variant, 'GRCh38', 'all').format_as_dict(test=True)
+        print(results)
+        assert 'NC_000008.11:g.143213308delinsGCGGG' in \
+               results['NM_178172.4:c.45_48dup']['primary_assembly_loci']['grch38']['hgvs_genomic_description']
+        assert 'NC_000008.10:g.144295187_144295190dup' in \
+               results['NM_178172.4:c.45_48dup']['primary_assembly_loci']['grch37']['hgvs_genomic_description']
 
     def test_issue_select_transcripts_from_genomic(self):
         variant = '["chr17:g.7576851_7576859delinsTA", "chr17:g.7576851_7576859delinsTT"]'

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -266,15 +266,24 @@ class TestVariantsAuto(TestCase):
         # of the ins span is == the ins, this is then normalised to a dup 1 base outside
         # of the transcript mapping. This may change without being incorrect, if mapping
         # / normalisation is altered, or data is updated again.
-        assert results['NM_001145026.2:c.715A>G']['primary_assembly_loci']['hg19'] == {
+        #  for NM_001145026.2 VS NC_000012.11 the transctipt mapping is
+        # strand 1 tx span 660:933, gen span 80849305:80849320 CIGAR 2=1X2=1X3=1X5=258D
+        # (now switched back to c->cg by mapping changes, should eventually end up as a
+        # genomic ins of 258 for GRCh37)
+
+        assert results['NM_001145026.2:c.715A>G']['primary_assembly_loci']['hg19'] in[{
             'hgvs_genomic_description': 'NC_000012.11:g.80849322dup',
-            'vcf': {'chr': 'chr12', 'pos': '80849321', 'ref': 'A', 'alt': 'AG'}}
+            'vcf': {'chr': 'chr12', 'pos': '80849321', 'ref': 'A', 'alt': 'AG'}}, {
+            'hgvs_genomic_description': 'NC_000012.11:g.80849320_80849321insG',
+            'vcf': {'chr': 'chr12', 'pos': '80849320', 'ref': 'C', 'alt': 'CG'}}]
         assert results['NM_001145026.2:c.715A>G']['primary_assembly_loci']['hg38'] == {
             'hgvs_genomic_description': 'NC_000012.12:g.80460707A>G',
             'vcf': {'chr': 'chr12', 'pos': '80460707', 'ref': 'A', 'alt': 'G'}}
-        assert results['NM_001145026.2:c.715A>G']['primary_assembly_loci']['grch37'] == {
+        assert results['NM_001145026.2:c.715A>G']['primary_assembly_loci']['grch37'] in [{
             'hgvs_genomic_description': 'NC_000012.11:g.80849322dup',
-            'vcf': {'chr': '12', 'pos': '80849321', 'ref': 'A', 'alt': 'AG'}}
+            'vcf': {'chr': '12', 'pos': '80849321', 'ref': 'A', 'alt': 'AG'}}, {
+            'hgvs_genomic_description': 'NC_000012.11:g.80849320_80849321insG',
+            'vcf': {'alt': 'CG', 'chr': '12', 'pos': '80849320', 'ref': 'C'}}]
         assert results['NM_001145026.2:c.715A>G']['primary_assembly_loci']['grch38'] == {
             'hgvs_genomic_description': 'NC_000012.12:g.80460707A>G',
             'vcf': {'chr': '12', 'pos': '80460707', 'ref': 'A', 'alt': 'G'}}
@@ -4204,12 +4213,12 @@ class TestVariantsAuto(TestCase):
         assert results['NM_001080423.3:c.1020del']['hgvs_lrg_variant'] == ''
         self.assertCountEqual(results['NM_001080423.3:c.1020del']['alt_genomic_loci'], [])
         assert results['NM_001080423.3:c.1020del']['primary_assembly_loci']['hg19']['hgvs_genomic_description'
-               ] == 'NC_000003.11:g.14561627_14561634='
+               ] in ['NC_000003.11:g.14561627_14561634=', 'NC_000003.11:g.14561628_14561633=']
         assert results['NM_001080423.3:c.1020del']['primary_assembly_loci']['hg38'] == {
             'hgvs_genomic_description': 'NC_000003.12:g.14520122del',
             'vcf': {'chr': 'chr3', 'pos': '14520119', 'ref': 'AG', 'alt': 'A'}}
         assert results['NM_001080423.3:c.1020del']['primary_assembly_loci']['grch37']['hgvs_genomic_description'
-               ] == 'NC_000003.11:g.14561627_14561634='
+               ] in ['NC_000003.11:g.14561627_14561634=', 'NC_000003.11:g.14561628_14561633=']
         assert results['NM_001080423.3:c.1020del']['primary_assembly_loci']['grch38'] == {
             'hgvs_genomic_description': 'NC_000003.12:g.14520122del',
             'vcf': {'chr': '3', 'pos': '14520119', 'ref': 'AG', 'alt': 'A'}}
@@ -4674,13 +4683,15 @@ class TestVariantsAuto(TestCase):
         assert results['NM_020469.2:c.261del']['hgvs_lrg_transcript_variant'] == ''
         assert results['NM_020469.2:c.261del']['hgvs_lrg_variant'] == ''
         assert results['NM_020469.2:c.261del']['primary_assembly_loci']['hg19'
-               ]['hgvs_genomic_description'] == 'NC_000009.11:g.136132906_136132913='
-        assert results['NM_020469.2:c.261del']['primary_assembly_loci']['hg38'
-               ]['hgvs_genomic_description'] == 'NC_000009.12:g.133257519_133257526='
+               ]['hgvs_genomic_description'] in [
+                       'NC_000009.11:g.136132906_136132913=','NC_000009.11:g.136132907_136132912=']
+        assert results['NM_020469.2:c.261del']['primary_assembly_loci']['hg38']['hgvs_genomic_description'
+                ] in ['NC_000009.12:g.133257519_133257526=','NC_000009.12:g.133257520_133257525=']
         assert results['NM_020469.2:c.261del']['primary_assembly_loci']['grch37'
-               ]['hgvs_genomic_description'] == 'NC_000009.11:g.136132906_136132913='
+               ]['hgvs_genomic_description'] in [
+                       'NC_000009.11:g.136132906_136132913=','NC_000009.11:g.136132907_136132912=']
         assert results['NM_020469.2:c.261del']['primary_assembly_loci']['grch38']['hgvs_genomic_description'
-               ] == 'NC_000009.12:g.133257519_133257526='
+                ] in ['NC_000009.12:g.133257519_133257526=','NC_000009.12:g.133257520_133257525=']
         assert results['NM_020469.2:c.261del']['reference_sequence_records'] == {
             'transcript': 'https://www.ncbi.nlm.nih.gov/nuccore/NM_020469.2',
             'protein': 'https://www.ncbi.nlm.nih.gov/nuccore/NP_065202.2',
@@ -4796,13 +4807,13 @@ class TestVariantsAuto(TestCase):
         assert results['NM_020469.2:c.261del']['hgvs_lrg_transcript_variant'] == ''
         assert results['NM_020469.2:c.261del']['hgvs_lrg_variant'] == ''
         assert results['NM_020469.2:c.261del']['primary_assembly_loci']['hg19']['hgvs_genomic_description'
-               ] == 'NC_000009.11:g.136132906_136132913='
+               ] in ['NC_000009.11:g.136132906_136132913=', 'NC_000009.11:g.136132907_136132912=']
         assert results['NM_020469.2:c.261del']['primary_assembly_loci']['hg38']['hgvs_genomic_description'
-               ] == 'NC_000009.12:g.133257519_133257526='
+               ] in ['NC_000009.12:g.133257519_133257526=','NC_000009.12:g.133257520_133257525=']
         assert results['NM_020469.2:c.261del']['primary_assembly_loci']['grch37']['hgvs_genomic_description'
-               ] == 'NC_000009.11:g.136132906_136132913='
+               ] in ['NC_000009.11:g.136132906_136132913=', 'NC_000009.11:g.136132907_136132912=']
         assert results['NM_020469.2:c.261del']['primary_assembly_loci']['grch38']['hgvs_genomic_description'
-               ] == 'NC_000009.12:g.133257519_133257526='
+               ] in ['NC_000009.12:g.133257519_133257526=','NC_000009.12:g.133257520_133257525=']
         assert results['NM_020469.2:c.261del']['reference_sequence_records'] == {
             'transcript': 'https://www.ncbi.nlm.nih.gov/nuccore/NM_020469.2',
             'protein': 'https://www.ncbi.nlm.nih.gov/nuccore/NP_065202.2',
@@ -5188,13 +5199,21 @@ class TestVariantsAuto(TestCase):
         assert results['NM_007121.5:c.519_521del']['hgvs_lrg_variant'] == ''
         self.assertCountEqual(results['NM_007121.5:c.519_521del']['alt_genomic_loci'], [])
         assert results['NM_007121.5:c.519_521del']['primary_assembly_loci']['hg19'][
-                   'hgvs_genomic_description'] == 'NC_000019.9:g.50881816_50881823='
+                'hgvs_genomic_description'] in [
+                        'NC_000019.9:g.50881816_50881823=',
+                        'NC_000019.9:g.50881817_50881822=']
         assert results['NM_007121.5:c.519_521del']['primary_assembly_loci']['hg38'][
-                   'hgvs_genomic_description'] == 'NC_000019.10:g.50378559_50378566='
+                   'hgvs_genomic_description'] in [
+                           'NC_000019.10:g.50378559_50378566=',
+                           'NC_000019.10:g.50378560_50378565=']
         assert results['NM_007121.5:c.519_521del']['primary_assembly_loci']['grch37'][
-                   'hgvs_genomic_description'] == 'NC_000019.9:g.50881816_50881823='
+                   'hgvs_genomic_description'] in[
+                           'NC_000019.9:g.50881816_50881823=',
+                           'NC_000019.9:g.50881817_50881822=']
         assert results['NM_007121.5:c.519_521del']['primary_assembly_loci']['grch38'][
-                   'hgvs_genomic_description'] == 'NC_000019.10:g.50378559_50378566='
+                   'hgvs_genomic_description'] in [
+                           'NC_000019.10:g.50378559_50378566=',
+                           'NC_000019.10:g.50378560_50378565=']
         assert results['NM_007121.5:c.519_521del']['reference_sequence_records'] == {
             'transcript': 'https://www.ncbi.nlm.nih.gov/nuccore/NM_007121.5',
             'protein': 'https://www.ncbi.nlm.nih.gov/nuccore/NP_009052.3'}
@@ -5214,13 +5233,21 @@ class TestVariantsAuto(TestCase):
         assert results['NM_001256647.1:c.228_230del']['hgvs_lrg_variant'] == ''
         self.assertCountEqual(results['NM_001256647.1:c.228_230del']['alt_genomic_loci'], [])
         assert results['NM_001256647.1:c.228_230del']['primary_assembly_loci']['hg19'][
-                   'hgvs_genomic_description'] == 'NC_000019.9:g.50881816_50881823='
+                   'hgvs_genomic_description'] in [
+                           'NC_000019.9:g.50881816_50881823=',
+                           'NC_000019.9:g.50881817_50881822=']
         assert results['NM_001256647.1:c.228_230del']['primary_assembly_loci']['hg38'][
-                   'hgvs_genomic_description'] == 'NC_000019.10:g.50378559_50378566='
+                   'hgvs_genomic_description'] in [
+                           'NC_000019.10:g.50378559_50378566=',
+                           'NC_000019.10:g.50378560_50378565=']
         assert results['NM_001256647.1:c.228_230del']['primary_assembly_loci']['grch37'][
-                   'hgvs_genomic_description'] == 'NC_000019.9:g.50881816_50881823='
+                   'hgvs_genomic_description'] in [
+                           'NC_000019.9:g.50881816_50881823=',
+                           'NC_000019.9:g.50881817_50881822=']
         assert results['NM_001256647.1:c.228_230del']['primary_assembly_loci']['grch38'][
-                   'hgvs_genomic_description'] == 'NC_000019.10:g.50378559_50378566='
+                   'hgvs_genomic_description'] in [
+                           'NC_000019.10:g.50378559_50378566=',
+                           'NC_000019.10:g.50378560_50378565=']
         assert results['NM_001256647.1:c.228_230del']['reference_sequence_records'] == {
             'transcript': 'https://www.ncbi.nlm.nih.gov/nuccore/NM_001256647.1',
             'protein': 'https://www.ncbi.nlm.nih.gov/nuccore/NP_001243576.1'}
@@ -6666,12 +6693,12 @@ class TestVariantsAuto(TestCase):
         assert results['NM_000949.6:c.*6528del']['hgvs_lrg_transcript_variant'] == ''
         assert results['NM_000949.6:c.*6528del']['hgvs_lrg_variant'] == ''
         assert results['NM_000949.6:c.*6528del']['primary_assembly_loci']['hg19']['hgvs_genomic_description'
-               ] == 'NC_000005.9:g.35058665_35058672='
+               ] in ['NC_000005.9:g.35058665_35058672=', 'NC_000005.9:g.35058666_35058671=']
         assert results['NM_000949.6:c.*6528del']['primary_assembly_loci']['hg38'] == {
             'hgvs_genomic_description': 'NC_000005.10:g.35058563del',
             'vcf': {'chr': 'chr5', 'pos': '35058560', 'ref': 'CA', 'alt': 'C'}}
         assert results['NM_000949.6:c.*6528del']['primary_assembly_loci']['grch37']['hgvs_genomic_description'
-               ] == 'NC_000005.9:g.35058665_35058672='
+               ] in ['NC_000005.9:g.35058665_35058672=', 'NC_000005.9:g.35058666_35058671=']
         assert results['NM_000949.6:c.*6528del']['primary_assembly_loci']['grch38'] == {
             'hgvs_genomic_description': 'NC_000005.10:g.35058563del',
             'vcf': {'chr': '5', 'pos': '35058560', 'ref': 'CA', 'alt': 'C'}}
@@ -6855,12 +6882,12 @@ class TestVariantsAuto(TestCase):
         assert results['NM_001204314.2:c.*6528del']['hgvs_lrg_variant'] == ''
         self.assertCountEqual(results['NM_001204314.2:c.*6528del']['alt_genomic_loci'], [])
         assert results['NM_001204314.2:c.*6528del']['primary_assembly_loci']['hg19']['hgvs_genomic_description'
-               ] == 'NC_000005.9:g.35058665_35058672='
+               ] in ['NC_000005.9:g.35058665_35058672=', 'NC_000005.9:g.35058666_35058671=']
         assert results['NM_001204314.2:c.*6528del']['primary_assembly_loci']['hg38'] == {
             'hgvs_genomic_description': 'NC_000005.10:g.35058563del',
             'vcf': {'chr': 'chr5', 'pos': '35058560', 'ref': 'CA', 'alt': 'C'}}
         assert results['NM_001204314.2:c.*6528del']['primary_assembly_loci']['grch37']['hgvs_genomic_description'
-               ] == 'NC_000005.9:g.35058665_35058672='
+               ] in ['NC_000005.9:g.35058665_35058672=', 'NC_000005.9:g.35058666_35058671=']
         assert results['NM_001204314.2:c.*6528del']['primary_assembly_loci']['grch38'] == {
             'hgvs_genomic_description': 'NC_000005.10:g.35058563del',
             'vcf': {'chr': '5', 'pos': '35058560', 'ref': 'CA', 'alt': 'C'}}
@@ -7577,12 +7604,12 @@ class TestVariantsAuto(TestCase):
         assert results['NM_015120.4:c.1577_1579del']['hgvs_lrg_transcript_variant'] == 'LRG_741t1:c.1577_1579del'
         assert results['NM_015120.4:c.1577_1579del']['hgvs_lrg_variant'] == 'LRG_741:g.67349_67351del'
         assert results['NM_015120.4:c.1577_1579del']['primary_assembly_loci']['hg19']['hgvs_genomic_description'
-               ] == 'NC_000002.11:g.73675223_73675230='
+               ] in ['NC_000002.11:g.73675223_73675230=','NC_000002.11:g.73675224_73675229=']
         assert results['NM_015120.4:c.1577_1579del']['primary_assembly_loci']['hg38'] == {
             'hgvs_genomic_description': 'NC_000002.12:g.73448101_73448103del',
             'vcf': {'chr': 'chr2', 'pos': '73448097', 'ref': 'TCTC', 'alt': 'T'}}
         assert results['NM_015120.4:c.1577_1579del']['primary_assembly_loci']['grch37']['hgvs_genomic_description'
-               ] == 'NC_000002.11:g.73675223_73675230='
+               ] in ['NC_000002.11:g.73675223_73675230=','NC_000002.11:g.73675224_73675229=']
         assert results['NM_015120.4:c.1577_1579del']['primary_assembly_loci']['grch38'] == {
             'hgvs_genomic_description': 'NC_000002.12:g.73448101_73448103del',
             'vcf': {'chr': '2', 'pos': '73448097', 'ref': 'TCTC', 'alt': 'T'}}
@@ -7647,10 +7674,10 @@ class TestVariantsAuto(TestCase):
         assert results['NM_001080423.2:c.1311del']['hgvs_lrg_variant'] == ''
         self.assertCountEqual(results['NM_001080423.2:c.1311del']['alt_genomic_loci'], [])
         assert results['NM_001080423.2:c.1311del']['primary_assembly_loci']['hg19']['hgvs_genomic_description'
-               ] == 'NC_000003.11:g.14561627_14561634='
+               ] in ['NC_000003.11:g.14561627_14561634=', 'NC_000003.11:g.14561628_14561633=']
         # # assert 'hg38' not in list(results['NM_001080423.2:c.1311del']['primary_assembly_loci'].keys())
         assert results['NM_001080423.2:c.1311del']['primary_assembly_loci']['grch37']['hgvs_genomic_description'
-               ] == 'NC_000003.11:g.14561627_14561634='
+               ] in ['NC_000003.11:g.14561627_14561634=', 'NC_000003.11:g.14561628_14561633=']
         # assert 'grch38' not in list(results['NM_001080423.2:c.1311del']['primary_assembly_loci'].keys())
         assert results['NM_001080423.2:c.1311del']['reference_sequence_records'] == {
             'transcript': 'https://www.ncbi.nlm.nih.gov/nuccore/NM_001080423.2',
@@ -7671,12 +7698,12 @@ class TestVariantsAuto(TestCase):
         assert results['NM_001080423.3:c.1020del']['hgvs_lrg_variant'] == ''
         self.assertCountEqual(results['NM_001080423.3:c.1020del']['alt_genomic_loci'], [])
         assert results['NM_001080423.3:c.1020del']['primary_assembly_loci']['hg19']['hgvs_genomic_description'
-               ] == 'NC_000003.11:g.14561627_14561634='
+               ] in ['NC_000003.11:g.14561627_14561634=', 'NC_000003.11:g.14561628_14561633=']
         assert results['NM_001080423.3:c.1020del']['primary_assembly_loci']['hg38'] == {
             'hgvs_genomic_description': 'NC_000003.12:g.14520122del',
             'vcf': {'chr': 'chr3', 'pos': '14520119', 'ref': 'AG', 'alt': 'A'}}
         assert results['NM_001080423.3:c.1020del']['primary_assembly_loci']['grch37']['hgvs_genomic_description'
-               ] == 'NC_000003.11:g.14561627_14561634='
+               ] in ['NC_000003.11:g.14561627_14561634=', 'NC_000003.11:g.14561628_14561633=']
         assert results['NM_001080423.3:c.1020del']['primary_assembly_loci']['grch38'] == {
             'hgvs_genomic_description': 'NC_000003.12:g.14520122del',
             'vcf': {'chr': '3', 'pos': '14520119', 'ref': 'AG', 'alt': 'A'}}
@@ -10585,12 +10612,12 @@ class TestVariantsAuto(TestCase):
         assert results['NM_001042545.1:c.3035del']['hgvs_lrg_variant'] == ''
         self.assertCountEqual(results['NM_001042545.1:c.3035del']['alt_genomic_loci'], [])
         assert results['NM_001042545.1:c.3035del']['primary_assembly_loci']['hg19']['hgvs_genomic_description'
-               ] == 'NC_000019.9:g.41123089_41123096='
+               ] in ['NC_000019.9:g.41123089_41123096=','NC_000019.9:g.41123090_41123095=']
         assert results['NM_001042545.1:c.3035del']['primary_assembly_loci']['hg38'] == {
             'hgvs_genomic_description': 'NC_000019.10:g.40617190del',
             'vcf': {'chr': 'chr19', 'pos': '40617187', 'ref': 'AG', 'alt': 'A'}}
         assert results['NM_001042545.1:c.3035del']['primary_assembly_loci']['grch37']['hgvs_genomic_description'
-               ] == 'NC_000019.9:g.41123089_41123096='
+               ] in ['NC_000019.9:g.41123089_41123096=','NC_000019.9:g.41123090_41123095=']
         assert results['NM_001042545.1:c.3035del']['primary_assembly_loci']['grch38'] == {
             'hgvs_genomic_description': 'NC_000019.10:g.40617190del',
             'vcf': {'chr': '19', 'pos': '40617187', 'ref': 'AG', 'alt': 'A'}}
@@ -10614,12 +10641,12 @@ class TestVariantsAuto(TestCase):
         assert results['NM_003573.2:c.3125del']['hgvs_lrg_variant'] == ''
         self.assertCountEqual(results['NM_003573.2:c.3125del']['alt_genomic_loci'], [])
         assert results['NM_003573.2:c.3125del']['primary_assembly_loci']['hg19']['hgvs_genomic_description'
-               ] == 'NC_000019.9:g.41123089_41123096='
+               ] in ['NC_000019.9:g.41123089_41123096=','NC_000019.9:g.41123090_41123095=']
         assert results['NM_003573.2:c.3125del']['primary_assembly_loci']['hg38'] == {
             'hgvs_genomic_description': 'NC_000019.10:g.40617190del',
             'vcf': {'chr': 'chr19', 'pos': '40617187', 'ref': 'AG', 'alt': 'A'}}
         assert results['NM_003573.2:c.3125del']['primary_assembly_loci']['grch37']['hgvs_genomic_description'
-               ] == 'NC_000019.9:g.41123089_41123096='
+               ] in ['NC_000019.9:g.41123089_41123096=','NC_000019.9:g.41123090_41123095=']
         assert results['NM_003573.2:c.3125del']['primary_assembly_loci']['grch38'] == {
             'hgvs_genomic_description': 'NC_000019.10:g.40617190del',
             'vcf': {'chr': '19', 'pos': '40617187', 'ref': 'AG', 'alt': 'A'}}
@@ -10643,12 +10670,12 @@ class TestVariantsAuto(TestCase):
         assert results['NM_001042544.1:c.3236del']['hgvs_lrg_variant'] == ''
         self.assertCountEqual(results['NM_001042544.1:c.3236del']['alt_genomic_loci'], [])
         assert results['NM_001042544.1:c.3236del']['primary_assembly_loci']['hg19']['hgvs_genomic_description'
-               ] == 'NC_000019.9:g.41123089_41123096='
+               ] in ['NC_000019.9:g.41123089_41123096=','NC_000019.9:g.41123090_41123095=']
         assert results['NM_001042544.1:c.3236del']['primary_assembly_loci']['hg38'] == {
             'hgvs_genomic_description': 'NC_000019.10:g.40617190del',
             'vcf': {'chr': 'chr19', 'pos': '40617187', 'ref': 'AG', 'alt': 'A'}}
         assert results['NM_001042544.1:c.3236del']['primary_assembly_loci']['grch37']['hgvs_genomic_description'
-               ] == 'NC_000019.9:g.41123089_41123096='
+               ] in ['NC_000019.9:g.41123089_41123096=','NC_000019.9:g.41123090_41123095=']
         assert results['NM_001042544.1:c.3236del']['primary_assembly_loci']['grch38'] == {
             'hgvs_genomic_description': 'NC_000019.10:g.40617190del',
             'vcf': {'chr': '19', 'pos': '40617187', 'ref': 'AG', 'alt': 'A'}}
@@ -30352,13 +30379,29 @@ class TestVariantsAuto(TestCase):
                    'hgvs_transcript_variant'] == 'NM_000061.2:c.588_589insCTACATAG'
         assert results['NM_000061.2:c.588_589insCTACATAG']['genome_context_intronic_sequence'] == ''
         assert results['NM_000061.2:c.588_589insCTACATAG']['refseqgene_context_intronic_sequence'] == ''
-        assert results['NM_000061.2:c.588_589insCTACATAG']['hgvs_refseqgene_variant'] == ''
+        assert results['NM_000061.2:c.588_589insCTACATAG'][
+                'hgvs_refseqgene_variant'] in ['', 'NG_009616.1:g.29053_30461del']
         assert results['NM_000061.2:c.588_589insCTACATAG']['hgvs_predicted_protein_consequence'] == {
             'tlr': 'NP_000052.1:p.(Ile197LeufsTer5)', 'slr': 'NP_000052.1:p.(I197Lfs*5)'}
+        # Variant exactly spans intron, and CTACATAG can be normalised out of the seq to get slightly
+        # less than whole intron del, with proper expansion this should probably map but given the
+        # intronic nature the ins could be at either end which complicates a more proper fix (should
+        # probably normalise to a dup of -9 to -1)
         assert results['NM_000061.2:c.588_589insCTACATAG'][
-                   'hgvs_lrg_transcript_variant'] == 'LRG_128t1:c.588_589insCTACATAG'
-        assert results['NM_000061.2:c.588_589insCTACATAG']['hgvs_lrg_variant'] == ''
-        self.assertCountEqual(results['NM_000061.2:c.588_589insCTACATAG']['alt_genomic_loci'], [])
+                'hgvs_lrg_transcript_variant'] in ['LRG_128t1:c.588_589insCTACATAG',
+                                                      'LRG_128t1:c.588+1_589-9del']
+        assert results['NM_000061.2:c.588_589insCTACATAG']['hgvs_lrg_variant'] in [
+                '',
+                'LRG_128:g.29053_30461del']
+
+        assert not results['NM_000061.2:c.588_589insCTACATAG']['alt_genomic_loci'] or \
+            results['NM_000061.2:c.588_589insCTACATAG']['alt_genomic_loci'] == [
+                {'grch37': {
+                    'hgvs_genomic_description': 'NW_004070883.1:g.42440_43848del',
+                    'vcf': {'chr': 'HG1439_PATCH', 'pos': '42440-43848', 'ref': 'N', 'alt': 'DEL'}}},
+                {'hg19': {
+                    'hgvs_genomic_description': 'NW_004070883.1:g.42440_43848del',
+                    'vcf': {'chr': 'NW_004070883.1', 'pos': '42440-43848', 'ref': 'N', 'alt': 'DEL'}}}]
 
         assert results['NM_000061.2:c.588_589insCTACATAG']['primary_assembly_loci']['hg19']['hgvs_genomic_description'] == 'NC_000023.10:g.100615752_100617160del'
         assert results['NM_000061.2:c.588_589insCTACATAG']['primary_assembly_loci']['grch37']['hgvs_genomic_description'] == 'NC_000023.10:g.100615752_100617160del'
@@ -30366,9 +30409,14 @@ class TestVariantsAuto(TestCase):
         assert results['NM_000061.2:c.588_589insCTACATAG']['primary_assembly_loci']['grch37']['vcf'] == {'chr': 'X', 'pos': '100615752-100617160','ref': 'N', 'alt': 'DEL'}
         assert results['NM_000061.2:c.588_589insCTACATAG']['primary_assembly_loci']['hg19']['vcf'] == {'chr': 'chrX', 'pos': '100615752-100617160','ref': 'N','alt': 'DEL'}
 
-        assert results['NM_000061.2:c.588_589insCTACATAG']['reference_sequence_records'] == {
+        assert results['NM_000061.2:c.588_589insCTACATAG']['reference_sequence_records'] in [{
             'transcript': 'https://www.ncbi.nlm.nih.gov/nuccore/NM_000061.2',
-            'protein': 'https://www.ncbi.nlm.nih.gov/nuccore/NP_000052.1'}
+            'protein': 'https://www.ncbi.nlm.nih.gov/nuccore/NP_000052.1'}, {
+            'transcript': 'https://www.ncbi.nlm.nih.gov/nuccore/NM_000061.2',
+            'protein': 'https://www.ncbi.nlm.nih.gov/nuccore/NP_000052.1',
+            'lrg': 'http://ftp.ebi.ac.uk/pub/databases/lrgex/LRG_128.xml',
+            'refseqgene': 'https://www.ncbi.nlm.nih.gov/nuccore/NG_009616.1'}]
+
 
     def test_variant335(self):
         variant = 'NM_000492.3:c.1210-12_1210-6delinsTTTTTTTTT'


### PR DESCRIPTION
Pull in the code to use the fixed C->G mapping and some associated fixes, this depends on a paired set of PRs one for vvhgvs and one for VF to work correctly, and so they need to be pulled in at the same time.

Unfortunatly this is the most complex of the 3 change sets, and probably needs the most detailed look through, the other 2 can be found in:
https://github.com/openvar/variantFormatter/pull/104
https://github.com/openvar/vv_hgvs/pull/24