### PR TITLE
feat: Align gene to transcript transcript filter

### DIFF
--- a/VariantValidator/modules/gene2transcripts.py
+++ b/VariantValidator/modules/gene2transcripts.py
@@ -283,6 +283,9 @@ def gene2transcripts(g2t, query, validator=False, bypass_web_searches=False, sel
             annotation = g2t.db.get_transcript_annotation(tx[3])
             if tx[3] in sel_tx_lst:
                 kept_tx.append(tx)
+
+            # The syntax if x in y is preferred here as it will prevent cases of ["NM_12345.6", "mane_select"] from
+            # causing issues by defaulting to mane_select (or others in the lists below)
             elif "mane_select" in sel_tx_lst:
                 if '"mane_select": true' in annotation:
                     kept_tx.append(tx)
@@ -293,8 +296,14 @@ def gene2transcripts(g2t, query, validator=False, bypass_web_searches=False, sel
                 if '"mane_select": true' in annotation or '"refseq_select": true' in annotation \
                         or '"ensembl_select": true' in annotation:
                     kept_tx.append(tx)
-            elif "all" in sel_tx_lst or None in sel_tx_lst:
+            elif "all" in sel_tx_lst or None in sel_tx_lst or "raw" in sel_tx_lst:
                 kept_tx.append(tx)
+
+        if "all" in sel_tx_lst:
+            logger.info("Set filter to all")
+            kept_tx = filter_latest_transcripts(kept_tx)
+
+        logger.info(f"Select Transcripts: {sel_tx_lst} retained transcripts {kept_tx}")
 
         tx_for_gene = kept_tx
 
@@ -412,7 +421,7 @@ def gene2transcripts(g2t, query, validator=False, bypass_web_searches=False, sel
                     error = 'Currently unable to update gene_ids or transcript information records because ' \
                             'VariantValidator %s' % str(e)
                     # my_variant.warnings.append(error)
-                    logger.info(error)
+                    logger.warning(error)
                 tx_description = g2t.db.get_transcript_description(tx)
 
             # Get annotation
@@ -533,6 +542,61 @@ def gene2transcripts(g2t, query, validator=False, bypass_web_searches=False, sel
     g2d_data["requested_symbol"] = submitted
 
     return g2d_data
+
+
+def get_accession_parts(accession):
+    """
+    Split transcript accession into base accession and version.
+
+    This function is different from the Validator object transcript_filter as it filters the return of tx_for gene and
+    not tx_for_region which has a different list structure.
+
+    Examples:
+        NM_000088.4 -> ('NM_000088', 4)
+        ENST00000225964.10 -> ('ENST00000225964', 10)
+        ENST00000486572.1/GRCh38 -> ('ENST00000486572', 1)
+    """
+
+    # remove optional genome build suffix
+    accession = accession.split("/")[0]
+
+    # split version
+    base, version = accession.rsplit(".", 1)
+
+    return base, int(version)
+
+
+def filter_latest_transcripts(rows):
+    """
+    Remove 'blat' rows and keep only latest transcript versions.
+    """
+
+    # remove blat rows
+    rows = [row for row in rows if row[5] != "blat"]
+
+    # find highest version per accession
+    latest_versions = {}
+
+    for row in rows:
+        base, version = get_accession_parts(row[3])
+
+        if (
+            base not in latest_versions
+            or version > latest_versions[base]
+        ):
+            latest_versions[base] = version
+
+    # keep only latest versions
+    filtered_rows = []
+
+    for row in rows:
+        base, version = get_accession_parts(row[3])
+
+        if version == latest_versions[base]:
+            filtered_rows.append(row)
+
+    return filtered_rows
+
 
 def lovd_syntax_check_g2t(query, lovd_syntax_check):
     # Get additional warnings

--- a/tests/test_gene2transcript.py
+++ b/tests/test_gene2transcript.py
@@ -169,6 +169,9 @@ class TestGene2Transcripts(unittest.TestCase):
         output_d = self.vv.gene2transcripts('BRCA2', select_transcripts='flibble')
         output_e = self.vv.gene2transcripts('BRAF', select_transcripts='mane_select')
         output_f = self.vv.gene2transcripts('BRAF', select_transcripts='mane')
+        output_g = self.vv.gene2transcripts('BRCA2', select_transcripts='all')
+        output_h = self.vv.gene2transcripts('BRCA2', select_transcripts='raw')
+
         print(output)
         assert len(output['transcripts']) >= 3
         assert len(output_b['transcripts']) == 1
@@ -176,6 +179,8 @@ class TestGene2Transcripts(unittest.TestCase):
         assert len(output_d['transcripts']) == 0
         assert len(output_e['transcripts']) == 1
         assert len(output_f['transcripts']) >= 2
+        assert (len(output_b['transcripts']) < len(output_c['transcripts']) < len(output_g['transcripts'])
+                < len(output_h['transcripts']))
 
     def test_symbol_valid_hgnc_id(self):
         symbol = 'HGNC:2197'


### PR DESCRIPTION
Old version does not discriminate between raw and all in select_transcripts field. This does not match VV anf VF processing and leads to slower responses when only latest transcript versions are required. Now, raw returns all transcripts at all versions and all returns all transcripts at latest versions. Closes issue https://github.com/openvar/variantValidator/issues/804