### PR TITLE
Global norm and map

### DIFF
--- a/VariantValidator/modules/mappers.py
+++ b/VariantValidator/modules/mappers.py
@@ -133,6 +133,8 @@ def gene_to_transcripts(variant, validator, select_transcripts_dict):
         try:
             var_dat, nw_rel_var = gap_mapper.gapped_g_to_c(rel_var, select_transcripts_dict)
         except Exception as e:
+            # import traceback
+            # traceback.print_exc()
             logger.info(f"nw_rel_var creation failed with exception {str(e)}")
             raise TranscriptMappingError(f"Encountered an issue when mapping genomic description "
                                          f"{variant.hgvs_formatted} to available transcripts")

--- a/VariantValidator/modules/variant.py
+++ b/VariantValidator/modules/variant.py
@@ -2,6 +2,10 @@ import re
 from . import utils as fn
 from .transcript_map_data import TranscriptMapData
 
+class VariantConfigurationError(Exception):
+    pass
+
+
 class Variant(object):
     """
     This Variant object will contain the original input, the processed variant description and any other data that's
@@ -81,6 +85,35 @@ class Variant(object):
         self.validated = False
         self.exonic_positions = None
         self.rna_data = None
+
+        # Mappers
+        self.evm = None
+        no_norm_evm = None
+        min_evm = None
+
+    def get_mappers(self, validator):
+        if validator is None:
+            raise VariantConfigurationError("VariantConfigurationError: Validator object is None")
+
+        if self.primary_assembly == "GRCh38" and validator.alt_aln_method == "splign":
+            self.evm = validator.splign_grch38_evm
+            self.no_norm_evm = validator.splign_grch38_no_norm_evm
+            self.min_evm = validator.splign_grch38_min_evm
+        elif self.primary_assembly == "GRCh37" and validator.alt_aln_method == "splign":
+            self.evm = validator.splign_grch37_evm
+            self.no_norm_evm = validator.splign_grch37_no_norm_evm
+            self.min_evm = validator.splign_grch37_min_evm
+        elif self.primary_assembly == "GRCh38" and validator.alt_aln_method == "genebuild":
+            self.evm = validator.genebuild_grch38_evm
+            self.no_norm_evm = validator.genebuild_grch38_no_norm_evm
+            self.min_evm = validator.genebuild_grch38_min_evm
+        elif self.primary_assembly == "GRCh37" and validator.alt_aln_method == "genebuild":
+            self.evm = validator.genebuild_grch37_evm
+            self.no_norm_evm = validator.genebuild_grch37_no_norm_evm
+            self.min_evm = validator.genebuild_grch37_min_evm
+        else:
+            raise VariantConfigurationError(f"VariantConfigurationError: Primary assembly {self.primary_assembly} "
+                                            f"is not supported.")
 
 
     def is_ascii(self):

--- a/VariantValidator/modules/vvMixinCore.py
+++ b/VariantValidator/modules/vvMixinCore.py
@@ -11,7 +11,6 @@ import sys
 import logging
 import json
 import time
-from vvhgvs.assemblymapper import AssemblyMapper
 from VariantValidator.modules import hgvs_utils
 from VariantValidator.modules import utils as fn
 from VariantValidator.modules import vvMixinConverters
@@ -187,29 +186,9 @@ class Mixin(vvMixinConverters.Mixin):
                         toskip = self._get_transcript_info(my_variant)
                         if toskip:
                             continue
-                        # Create easy variant mapper (over variant mapper) and splign locked evm
-                        my_variant.evm = AssemblyMapper(self.hdp,
-                                                        assembly_name=primary_assembly,
-                                                        alt_aln_method=self.alt_aln_method,
-                                                        normalize=True,
-                                                        replace_reference=True
-                                                        )
 
-                        # Setup a reverse normalize instance and non-normalize evm
-                        my_variant.no_norm_evm = AssemblyMapper(self.hdp,
-                                                                assembly_name=primary_assembly,
-                                                                alt_aln_method=self.alt_aln_method,
-                                                                normalize=False,
-                                                                replace_reference=True
-                                                                )
-
-                        # Create a specific minimal evm with no normalizer and no replace_reference
-                        my_variant.min_evm = AssemblyMapper(self.hdp,
-                                                            assembly_name=primary_assembly,
-                                                            alt_aln_method=self.alt_aln_method,
-                                                            normalize=False,
-                                                            replace_reference=False
-                                                            )
+                        # Configure mappers
+                        my_variant.get_mappers(self)
 
                     if my_variant.reftype in [':c.', ':n.']:
                         my_variant.gene_symbol = self.db.get_gene_symbol_from_transcript_id(
@@ -326,7 +305,7 @@ class Mixin(vvMixinConverters.Mixin):
 
                     # Create the additional required normalizers which come from allele merge code and other sources
                     self.primary_assembly = primary_assembly
-                    self.create_additional_normalizers_and_mappers()
+                    self.get_normalizers()
 
                     logger.debug("Completed string formatting")
 
@@ -405,21 +384,8 @@ class Mixin(vvMixinConverters.Mixin):
                                 test_variant.hgvs_formatted = self.hp.parse_hgvs_variant(
                                         test_variant.hgvs_formatted)
 
-                            # Create easy variant mapper (over variant mapper) and splign locked evm
-                            test_variant.evm = AssemblyMapper(self.hdp,
-                                                              assembly_name=primary_assembly,
-                                                              alt_aln_method=self.alt_aln_method,
-                                                              normalize=True,
-                                                              replace_reference=True
-                                                              )
-
-                            # Setup a reverse normalize instance and non-normalize evm
-                            test_variant.no_norm_evm = AssemblyMapper(self.hdp,
-                                                                      assembly_name=primary_assembly,
-                                                                      alt_aln_method=self.alt_aln_method,
-                                                                      normalize=False,
-                                                                      replace_reference=True
-                                                                      )
+                            # Configure mappers
+                            my_variant.get_mappers(self)
 
                             mappers.transcripts_to_gene(test_variant, self, select_transcripts_dict_plus_version)
                         except mappers.MappersError:
@@ -561,30 +527,8 @@ class Mixin(vvMixinConverters.Mixin):
                         # These objects cannot be moved outside of the main function because they gather data from the
                         # user input e.g. alignment method and genome build
                         # They initiate quickly, so no need to move them unnecessarily
+                        my_variant.get_mappers(self)
 
-                        # Create easy variant mapper (over variant mapper) and splign locked evm
-                        my_variant.evm = AssemblyMapper(self.hdp,
-                                                        assembly_name=primary_assembly,
-                                                        alt_aln_method=self.alt_aln_method,
-                                                        normalize=True,
-                                                        replace_reference=True
-                                                        )
-
-                        # Setup a reverse normalize instance and non-normalize evm
-                        my_variant.no_norm_evm = AssemblyMapper(self.hdp,
-                                                                assembly_name=primary_assembly,
-                                                                alt_aln_method=self.alt_aln_method,
-                                                                normalize=False,
-                                                                replace_reference=True
-                                                                )
-
-                        # Create a specific minimal evm with no normalizer and no replace_reference
-                        my_variant.min_evm = AssemblyMapper(self.hdp,
-                                                            assembly_name=primary_assembly,
-                                                            alt_aln_method=self.alt_aln_method,
-                                                            normalize=False,
-                                                            replace_reference=False
-                                                            )
 
                     else:
                         error = 'Mapping of ' + formatted_variant + ' to genome assembly ' + \

--- a/VariantValidator/modules/vvMixinCore.py
+++ b/VariantValidator/modules/vvMixinCore.py
@@ -1664,6 +1664,8 @@ class Mixin(vvMixinConverters.Mixin):
                 "Unhandled validation failure",
                 exc_info=True,
             )
+            # import traceback
+            # traceback.print_exc()
             raise fn.VariantValidatorError("Validation error") from e
 
     def gene2transcripts(self, query, validator=False, bypass_web_searches=False, select_transcripts=None,

--- a/VariantValidator/modules/vvMixinInit.py
+++ b/VariantValidator/modules/vvMixinInit.py
@@ -4,7 +4,6 @@ import vvhgvs
 import vvhgvs.parser
 import vvhgvs.dataproviders.uta
 import vvhgvs.dataproviders.seqfetcher
-import vvhgvs.assemblymapper
 import vvhgvs.variantmapper
 import vvhgvs.sequencevariant
 import vvhgvs.validator
@@ -27,6 +26,7 @@ from VariantValidator.settings import CONFIG_DIR
 from VariantValidator.version import __version__
 from VariantValidator.modules.hgvs_utils import hgvs_delins_parts_to_hgvs_obj,\
         VVPosEdit
+from vvhgvs.assemblymapper import AssemblyMapper
 
 logger = logging.getLogger(__name__)
 
@@ -228,6 +228,97 @@ class Mixin:
            validate=False
         )
 
+        """
+        Global Mappers
+        """
+
+        # Create easy variant mapper (over variant mapper) and splign locked evm
+        self.splign_grch38_evm = AssemblyMapper(self.hdp,
+                                                assembly_name="GRCh38",
+                                                alt_aln_method="splign",
+                                                normalize=True,
+                                                replace_reference=True
+                                                )
+
+        self.splign_grch37_evm = AssemblyMapper(self.hdp,
+                                                assembly_name="GRCh37",
+                                                alt_aln_method="splign",
+                                                normalize=True,
+                                                replace_reference=True
+                                                )
+
+        self.genebuild_grch38_evm = AssemblyMapper(self.hdp,
+                                                   assembly_name="GRCh38",
+                                                   alt_aln_method="genebuild",
+                                                   normalize=True,
+                                                   replace_reference=True
+                                                   )
+
+        self.genebuild_grch37_evm = AssemblyMapper(self.hdp,
+                                                   assembly_name="GRCh37",
+                                                   alt_aln_method="genebuild",
+                                                   normalize=True,
+                                                   replace_reference=True
+                                                   )
+
+        # Create non-normalizing evms
+        self.splign_grch38_no_norm_evm = AssemblyMapper(self.hdp,
+                                                        assembly_name="GRCh38",
+                                                        alt_aln_method="splign",
+                                                        normalize=False,
+                                                        replace_reference=True
+                                                        )
+
+        self.splign_grch37_no_norm_evm = AssemblyMapper(self.hdp,
+                                                        assembly_name="GRCh37",
+                                                        alt_aln_method="splign",
+                                                        normalize=False,
+                                                        replace_reference=True
+                                                        )
+
+        self.genebuild_grch38_no_norm_evm = AssemblyMapper(self.hdp,
+                                                           assembly_name="GRCh38",
+                                                           alt_aln_method="genebuild",
+                                                           normalize=False,
+                                                           replace_reference=True
+                                                           )
+
+        self.genebuild_grch37_no_norm_evm = AssemblyMapper(self.hdp,
+                                                           assembly_name="GRCh37",
+                                                           alt_aln_method="genebuild",
+                                                           normalize=False,
+                                                           replace_reference=True
+                                                           )
+
+        # Create a specific minimal evm with no normalizer and no replace_reference
+        self.splign_grch38_min_evm = AssemblyMapper(self.hdp,
+                                                    assembly_name="GRCh38",
+                                                    alt_aln_method="splign",
+                                                    normalize=False,
+                                                    replace_reference=False
+                                                    )
+
+        self.splign_grch37_min_evm = AssemblyMapper(self.hdp,
+                                                    assembly_name="GRCh37",
+                                                    alt_aln_method="splign",
+                                                    normalize=False,
+                                                    replace_reference=False
+                                                    )
+
+        self.genebuild_grch38_min_evm = AssemblyMapper(self.hdp,
+                                                       assembly_name="GRCh38",
+                                                       alt_aln_method="genebuild",
+                                                       normalize=False,
+                                                       replace_reference=False
+                                                       )
+
+        self.genebuild_grch37_min_evm = AssemblyMapper(self.hdp,
+                                                       assembly_name="GRCh37",
+                                                       alt_aln_method="genebuild",
+                                                       normalize=False,
+                                                       replace_reference=False
+                                                       )
+
         # Created during validate method
         self.selected_assembly = None
         self.select_transcripts = None
@@ -240,10 +331,8 @@ class Mixin:
         self.merge_normalizer = None
         self.reverse_merge_normalizer = None
 
-
-
     # Create additional normalizers
-    def create_additional_normalizers_and_mappers(self):
+    def get_normalizers(self):
         """
         Keep the internal function for VV to prevent a lot of unnecessary recoding
         but source the mappers and normalizers from the global setup
@@ -275,13 +364,6 @@ class Mixin:
             self.reverse_merge_normalizer = self.genebuild_reverse_merge_normalizer
         else:
             raise InitialisationError("ConfigurationError: Unknown alt_aln_method: " + self.alt_aln_method)
-
-        self.no_norm_evm = vvhgvs.assemblymapper.AssemblyMapper(self.hdp,
-                                                                assembly_name=self.primary_assembly,
-                                                                alt_aln_method=self.alt_aln_method,
-                                                                normalize=False,
-                                                                replace_reference=True
-                                                                )
 
     def __del__(self):
         try:

--- a/VariantValidator/modules/vvMixinInit.py
+++ b/VariantValidator/modules/vvMixinInit.py
@@ -153,8 +153,9 @@ class Mixin:
         self.genome_builds = ['GRCh37', 'hg19', 'GRCh38']
         self.utaSchema = str(self.hdp.data_version())
 
-        # When we are able to access Ensembl data we will need to use these normalizer instances
-        # These are currently implemented in VF
+        """
+        Global Normalizers
+        """
         self.splign_normalizer = vvhgvs.normalizer.Normalizer(
             self.hdp,
             cross_boundaries=False,
@@ -167,6 +168,13 @@ class Mixin:
             cross_boundaries=False,
             shuffle_direction=vvhgvs.global_config.normalizer.shuffle_direction,
             alt_aln_method='genebuild'  # Ensembl
+            )
+
+        self.splign_normalizer_cross = vvhgvs.normalizer.Normalizer(
+            self.hdp,
+            cross_boundaries=True,
+            shuffle_direction=vvhgvs.global_config.normalizer.shuffle_direction,
+            alt_aln_method='splign'  # Ensembl
             )
 
         self.genebuild_normalizer_cross = vvhgvs.normalizer.Normalizer(
@@ -188,41 +196,85 @@ class Mixin:
                                                                          alt_aln_method='genebuild' # Ensembl
                                                                          )
 
+        self.splign_merge_normalizer = vvhgvs.normalizer.Normalizer(
+           self.hdp,
+           cross_boundaries=False,
+           shuffle_direction=vvhgvs.global_config.normalizer.shuffle_direction,
+           alt_aln_method='splign',
+           validate=False
+        )
+
+        self.splign_reverse_merge_normalizer = vvhgvs.normalizer.Normalizer(
+           self.hdp,
+           cross_boundaries=False,
+           shuffle_direction=5,
+           alt_aln_method='splign',
+           validate=False
+        )
+
+        self.genebuild_merge_normalizer = vvhgvs.normalizer.Normalizer(
+           self.hdp,
+           cross_boundaries=False,
+           shuffle_direction=vvhgvs.global_config.normalizer.shuffle_direction,
+           alt_aln_method='genebuild',
+           validate=False
+        )
+
+        self.genebuild_reverse_merge_normalizer = vvhgvs.normalizer.Normalizer(
+           self.hdp,
+           cross_boundaries=False,
+           shuffle_direction=5,
+           alt_aln_method='genebuild',
+           validate=False
+        )
+
         # Created during validate method
         self.selected_assembly = None
         self.select_transcripts = None
         self.alt_aln_method = None
         self.batch_list = []
 
+        # VV selected tools
+        self.reverse_hn = None
+        self.hn = None
+        self.merge_normalizer = None
+        self.reverse_merge_normalizer = None
+
+
+
     # Create additional normalizers
     def create_additional_normalizers_and_mappers(self):
-        self.reverse_hn = vvhgvs.normalizer.Normalizer(self.hdp,
-                                                       cross_boundaries=False,
-                                                       shuffle_direction=5,
-                                                       alt_aln_method=self.alt_aln_method
-                                                       )
+        """
+        Keep the internal function for VV to prevent a lot of unnecessary recoding
+        but source the mappers and normalizers from the global setup
+        """
+        if self.alt_aln_method == "splign":
+            self.reverse_hn = self.reverse_splign_normalizer
+        elif self.alt_aln_method == "genebuild":
+            self.reverse_hn = self.reverse_genebuild_normalizer
+        else:
+            raise InitialisationError("ConfigurationError: Unknown alt_aln_method: " + self.alt_aln_method)
 
-        self.hn = vvhgvs.normalizer.Normalizer(self.hdp,
-                                               cross_boundaries=False,
-                                               shuffle_direction=3,
-                                               alt_aln_method=self.alt_aln_method
-                                               )
+        if self.alt_aln_method == "splign":
+            self.hn = self.splign_normalizer
+        elif self.alt_aln_method == "genebuild":
+            self.hn = self.genebuild_normalizer
+        else:
+            raise InitialisationError("ConfigurationError: Unknown alt_aln_method: " + self.alt_aln_method)
 
-        self.merge_normalizer = vvhgvs.normalizer.Normalizer(
-           self.hdp,
-           cross_boundaries=False,
-           shuffle_direction=vvhgvs.global_config.normalizer.shuffle_direction,
-           alt_aln_method=self.alt_aln_method,
-           validate=False
-        )
+        if self.alt_aln_method == "splign":
+            self.merge_normalizer = self.splign_merge_normalizer
+        elif self.alt_aln_method == "genebuild":
+            self.merge_normalizer = self.genebuild_merge_normalizer
+        else:
+            raise InitialisationError("ConfigurationError: Unknown alt_aln_method: " + self.alt_aln_method)
 
-        self.reverse_merge_normalizer = vvhgvs.normalizer.Normalizer(
-           self.hdp,
-           cross_boundaries=False,
-           shuffle_direction=5,
-           alt_aln_method=self.alt_aln_method,
-           validate=False
-        )
+        if self.alt_aln_method == "splign":
+            self.reverse_merge_normalizer = self.splign_reverse_merge_normalizer
+        elif self.alt_aln_method == "genebuild":
+            self.reverse_merge_normalizer = self.genebuild_reverse_merge_normalizer
+        else:
+            raise InitialisationError("ConfigurationError: Unknown alt_aln_method: " + self.alt_aln_method)
 
         self.no_norm_evm = vvhgvs.assemblymapper.AssemblyMapper(self.hdp,
                                                                 assembly_name=self.primary_assembly,


### PR DESCRIPTION
PR merges in the use of global normalizers and mappers

@John-F-Wagstaff, tests for exon boundary crossing in expanded_repeats.py
are failing. It is not clear to me how to pass the global mappers correctly.