### PR TITLE
Improve warnings is transcript selection errors

### DIFF
--- a/VariantValidator/modules/mappers.py
+++ b/VariantValidator/modules/mappers.py
@@ -118,7 +118,7 @@ def gene_to_transcripts(variant, validator, select_transcripts_dict):
     """
     # Keep error messages consistent with later by pre-storing
     no_tx_found_error = (
-        "No individual transcripts have been identified that fully overlap the "
+        "TranscriptIdentificationWarning: No individual transcripts have been identified that fully overlap the "
         "described variation in the genomic sequence. Large variants might span"
         " one or more genes and are currently only described at the genome (g.)"
         " level.")
@@ -153,7 +153,7 @@ def gene_to_transcripts(variant, validator, select_transcripts_dict):
                 variant.output_type_flag = 'intergenic'
                 # set genomic and where available RefSeqGene outputs
                 variant.warnings.append(no_tx_found_error)
-                error = 'Mapping unavailable for RefSeqGene ' + str(variant.hgvs_formatted) + \
+                error = 'TranscriptIdentificationWarning: Mapping unavailable for RefSeqGene ' + str(variant.hgvs_formatted) + \
                         ' using alignment method = ' + validator.alt_aln_method
                 variant.warnings.append(error)
                 variant.genomic_r = variant.hgvs_formatted
@@ -173,7 +173,7 @@ def gene_to_transcripts(variant, validator, select_transcripts_dict):
                 validator.batch_list.append(query)
                 logger.info('Submitting new variant with format %s', genomic_input)
             else:
-                error = 'Mapping unavailable for RefSeqGene ' + str(variant.hgvs_formatted) + \
+                error = 'TranscriptIdentificationWarning: Mapping unavailable for RefSeqGene ' + str(variant.hgvs_formatted) + \
                         ' using alignment method = ' + validator.alt_aln_method
                 variant.warnings.append(error)
                 logger.info(str(error))
@@ -203,11 +203,11 @@ def gene_to_transcripts(variant, validator, select_transcripts_dict):
                         rsg_data = ['']
 
                     if validator.select_transcripts not in ['all', 'raw', 'select', 'mane_select', 'mane']:
-                        error = (f'None of the specified transcripts ({validator.select_transcripts}) '
+                        error = (f'TranscriptSelectionError: None of the specified transcripts ({validator.select_transcripts}) '
                                  f'fully overlap the described variation in '
                                  f'the genomic sequence. Try selecting one of the default options')
                     elif validator.select_transcripts not in ['raw'] and unrestricted_map_found:
-                        error = ('Transcripts were found but the current transcript type limitation (of '
+                        error = ('TranscriptSelectionError: Transcripts were found but the current transcript type limitation (of '
                                  f'{validator.select_transcripts}) removed all transcripts that overlap '
                                  'the described variation in the genomic sequence. You may want to try '
                                  'selecting less restrictive setting for this variant.')
@@ -287,8 +287,15 @@ def transcripts_to_gene(variant, validator, select_transcripts_dict_plus_version
             "mane" not in validator.select_transcripts and "refseqgene" not in validator.select_transcripts:
         if tx_ac not in list(select_transcripts_dict_plus_version.keys()):
             # By marking it as Do Not Write and continuing through the validation loop
-            variant.write = False
-            return True
+            if ":g." not in variant.original:
+                error = (f"TranscriptSelectionError: Variant {variant.hgvs_formatted} is not in the list of "
+                       f"transcripts selected for validation {validator.select_transcripts}")
+                logger.info(error)
+                variant.warnings.append(error)
+                raise MappersError(error)
+            else:
+                variant.write = False
+                return True
 
     # Se rec_var to '' so it can be updated later
     rec_var = ''

--- a/VariantValidator/modules/vvMixinCore.py
+++ b/VariantValidator/modules/vvMixinCore.py
@@ -750,10 +750,10 @@ class Mixin(vvMixinConverters.Mixin):
                 # Runtime information and errors at warning and above only!!! #
                 ###############################################################
 
-                structure_loop_variant  = (f"Structure loop for variant {variant.original}, "
-                                           f"genome build {selected_assembly}, "
-                                           f"reference set {transcript_set}, "
-                                           f"select transcripts: {select_transcripts}")
+                structure_loop_variant = (f"Structure loop for variant {variant.original}, "
+                                          f"genome build {selected_assembly}, "
+                                          f"reference set {transcript_set}, "
+                                          f"select transcripts: {select_transcripts}")
 
                 logger.warning(structure_loop_variant)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -29,7 +29,8 @@ class TestValidator(unittest.TestCase):
 
         output = self.vv.validate(var, 'GRCh37', 'Trans1').format_as_dict()
         print(output)
-        self.assertEqual(output['flag'], 'empty_result')
+        self.assertEqual(output['flag'], 'warning')
+        assert "TranscriptSelectionError" in str(output["validation_warning_1"]["validation_warnings"])
 
     def test_transcript_list_realid(self):
         var = 'NM_015120.4:c.34C>T'
@@ -52,7 +53,8 @@ class TestValidator(unittest.TestCase):
 
         output = self.vv.validate(var, 'GRCh37', 'LRG1').format_as_dict()
         print(output)
-        self.assertEqual(output['flag'], 'empty_result')
+        self.assertEqual(output['flag'], 'warning')
+        assert "TranscriptSelectionError" in str(output["validation_warning_1"]["validation_warnings"])
 
     def test_non_ascii(self):
         var = 'NM_015120.4:c.34C>T\202'

--- a/tests/test_expanded_repeats.py
+++ b/tests/test_expanded_repeats.py
@@ -1089,7 +1089,7 @@ class TestExpandedRepeatRefSeqGenomic(TestCase):
             " the core HGVS descriptions provided",
             'NG_012232.1:g.6_7insTTTTTTTTTTTTTTTT automapped to genome position '
             'NC_000023.10:g.33362724_33362725insAAAAAAAAAAAAAAAA',
-            'No individual transcripts have been identified that fully overlap the described variation in the genomic sequence. Large variants might span one or more genes and are currently only described at the genome (g.) level.'
+            'TranscriptIdentificationWarning: No individual transcripts have been identified that fully overlap the described variation in the genomic sequence. Large variants might span one or more genes and are currently only described at the genome (g.) level.'
         ]
 
     def test_RSG_genomic_single_position_to_span(self):
@@ -1101,12 +1101,7 @@ class TestExpandedRepeatRefSeqGenomic(TestCase):
         print(results)
         assert results["intergenic_variant_1"]["primary_assembly_loci"]["grch37"][
                 "hgvs_genomic_description"] == "NC_000023.10:g.33362724_33362725insAAAAAAAAAAAAAAAA"
-        assert results['intergenic_variant_1']["validation_warnings"] ==  [
-            "ExpandedRepeatError: The coordinates for the repeat region are stated incorrectly in the submitted description NG_012232.1:g.4T[20]. The corrected description is NG_012232.1:g.3_6T[20]",
-            "ExpandedRepeatWarning: NG_012232.1:g.3_6T[20] should only be used as an annotation for the core HGVS descriptions provided",
-            "NG_012232.1:g.6_7insTTTTTTTTTTTTTTTT automapped to genome position NC_000023.10:g.33362724_33362725insAAAAAAAAAAAAAAAA",
-            'No individual transcripts have been identified that fully overlap the described variation in the genomic sequence. Large variants might span one or more genes and are currently only described at the genome (g.) level.'
-        ]
+        assert results['intergenic_variant_1']["validation_warnings"] ==  ['ExpandedRepeatError: The coordinates for the repeat region are stated incorrectly in the submitted description NG_012232.1:g.4T[20]. The corrected description is NG_012232.1:g.3_6T[20]', 'ExpandedRepeatWarning: NG_012232.1:g.3_6T[20] should only be used as an annotation for the core HGVS descriptions provided', 'NG_012232.1:g.6_7insTTTTTTTTTTTTTTTT automapped to genome position NC_000023.10:g.33362724_33362725insAAAAAAAAAAAAAAAA', 'TranscriptIdentificationWarning: No individual transcripts have been identified that fully overlap the described variation in the genomic sequence. Large variants might span one or more genes and are currently only described at the genome (g.) level.']
 
     def test_incorrect_RSG_genomic_range(self):
         """
@@ -1283,12 +1278,7 @@ class TestExpandedRepeaLocusReferenceGenomic(TestCase):
         print(results)
         assert results["intergenic_variant_1"]["primary_assembly_loci"]["grch37"][
                 "hgvs_genomic_description"] == "NC_000023.10:g.33362724_33362725insAAAAAAAAAAAAAAAA"
-        assert results['intergenic_variant_1']["validation_warnings"] == [
-            "ExpandedRepeatError: The coordinates for the repeat region are stated incorrectly in the submitted description LRG_199:g.4T[20]. The corrected description is NG_012232.1:g.3_6T[20]",
-            "ExpandedRepeatWarning: NG_012232.1:g.3_6T[20] should only be used as an annotation for the core HGVS descriptions provided",
-            "NG_012232.1:g.6_7insTTTTTTTTTTTTTTTT automapped to genome position NC_000023.10:g.33362724_33362725insAAAAAAAAAAAAAAAA",
-            "No individual transcripts have been identified that fully overlap the described variation in the genomic sequence. Large variants might span one or more genes and are currently only described at the genome (g.) level."
-        ]
+        assert results['intergenic_variant_1']["validation_warnings"] == ['ExpandedRepeatError: The coordinates for the repeat region are stated incorrectly in the submitted description LRG_199:g.4T[20]. The corrected description is NG_012232.1:g.3_6T[20]', 'ExpandedRepeatWarning: NG_012232.1:g.3_6T[20] should only be used as an annotation for the core HGVS descriptions provided', 'NG_012232.1:g.6_7insTTTTTTTTTTTTTTTT automapped to genome position NC_000023.10:g.33362724_33362725insAAAAAAAAAAAAAAAA', 'TranscriptIdentificationWarning: No individual transcripts have been identified that fully overlap the described variation in the genomic sequence. Large variants might span one or more genes and are currently only described at the genome (g.) level.']
 
     def test_incorrect_LRG_genomic_range(self):
         """

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -31298,8 +31298,8 @@ class TestVariantsAuto(TestCase):
             "refseqgene": "https://www.ncbi.nlm.nih.gov/nuccore/NG_029236.1" }
 
         assert results["intergenic_variant_1"]["validation_warnings"] == [
-            "No individual transcripts have been identified that fully overlap the described variation in the genomic sequence. Large variants might span one or more genes and are currently only described at the genome (g.) level.",
-            "Mapping unavailable for RefSeqGene NG_029236.1:g.501delG using alignment method = splign"
+            "TranscriptIdentificationWarning: No individual transcripts have been identified that fully overlap the described variation in the genomic sequence. Large variants might span one or more genes and are currently only described at the genome (g.) level.",
+            "TranscriptIdentificationWarning: Mapping unavailable for RefSeqGene NG_029236.1:g.501delG using alignment method = splign"
         ]
 
 

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -1404,6 +1404,12 @@ class TestVVGapWarnings(TestCase):
         print(results)
         assert "UncertainConversionError: Validation of NM_033360.3:c.574+1_575-1del - Variant coordinate is out of the bound of CDS region (CDS length : 570)" in results['validation_warning_1']['validation_warnings']
 
+    def test_incorrect_transcript_selection_for_nm(self):
+        variant = 'NM_000088.4:c.589G>T'
+        results = self.vv.validate(variant, 'GRCh38', '["NM_000089.4", "NM_000089.3"]', transcript_set="refseq").format_as_dict(test=True)
+        print(results)
+        assert "TranscriptSelectionError: Variant NM_000088.4:c.589G>T is not in the list of transcripts selected for validation [\"NM_000089.4\", \"NM_000089.3\"]" in results['validation_warning_1']['validation_warnings']
+
 # <LICENSE>
 # Copyright (C) 2016-2026 VariantValidator Contributors
 #


### PR DESCRIPTION
This commit adds error codes to existing transcript selection warnings. It also now warns if a transcript variant is submitted with a non-matching transcript selection, rather than the old behavior which resulted in a lost result and could become empty.