### PR TITLE
Correct import bug in gapped_mapping.py and add GapWarning to all gaps

### DIFF
--- a/VariantValidator/modules/gapped_mapping.py
+++ b/VariantValidator/modules/gapped_mapping.py
@@ -7,6 +7,9 @@ from VariantValidator.modules.hgvs_utils import hgvs_delins_parts_to_hgvs_obj, h
 from VariantValidator.modules.variant import TranscriptMapData
 from VariantValidator.modules.utils import simple_dna_revcomp
 
+# Add missing import - Was never imported
+# from VariantValidator.modules.hgvs_utils import hgvs_obj_from_existing_edit
+
 logger = logging.getLogger(__name__)
 
 # New function for handling insertion type gapped mappings, relies on, and should only trigger with
@@ -1144,13 +1147,16 @@ it is an artefact of aligning %s with %s (genome build %s)""" % (tx_ac, gen_ac, 
                     hgvs_refreshed_variant = self.edit_output(hgvs_refreshed_variant, saved_hgvs_coding)
 
                     # Send to empty nw_rel_var
-                    if hgvs_refreshed_variant.posedit.edit.type == "delins" and \
-                            hgvs_refreshed_variant.posedit.edit.alt == "":
-                        hgvs_refreshed_variant = hgvs_obj_from_existing_edit(
-                                hgvs_refreshed_variant.ac,
-                                hgvs_refreshed_variant.type,
-                                hgvs_refreshed_variant.posedit.pos,
-                                '',hgvs_refreshed_variant.posedit.edit.ref)
+                    # Never used because module was not imported
+
+                    # if hgvs_refreshed_variant.posedit.edit.type == "delins" and \
+                    #         hgvs_refreshed_variant.posedit.edit.alt == "":
+                    #     hgvs_refreshed_variant = hgvs_obj_from_existing_edit(
+                    #             hgvs_refreshed_variant.ac,
+                    #             hgvs_refreshed_variant.type,
+                    #             hgvs_refreshed_variant.posedit.pos,
+                    #             '',hgvs_refreshed_variant.posedit.edit.ref)
+
                     nw_rel_var.append(hgvs_refreshed_variant)
 
                 # Otherwise these variants need to be set
@@ -3266,13 +3272,15 @@ it is an artefact of aligning %s with %s (genome build %s)""" % (tx_ac, gen_ac, 
                     "Unsupported normalization of variants spanning the UTR-exon boundary" in error:
                 hgvs_refreshed_variant = saved_hgvs_coding
 
-                if hgvs_refreshed_variant.posedit.edit.type == 'delins' and \
-                        hgvs_refreshed_variant.posedit.edit.alt == "":
-                    hgvs_refreshed_variant = hgvs_obj_from_existing_edit(
-                            hgvs_refreshed_variant.ac,
-                            hgvs_refreshed_variant.type,
-                            hgvs_refreshed_variant.posedit.pos,
-                            hgvs_refreshed_variant.posedit.edit.ref,'')
+                # Never used because module was not imported
+
+                # if hgvs_refreshed_variant.posedit.edit.type == 'delins' and \
+                #         hgvs_refreshed_variant.posedit.edit.alt == "":
+                #     hgvs_refreshed_variant = hgvs_obj_from_existing_edit(
+                #             hgvs_refreshed_variant.ac,
+                #             hgvs_refreshed_variant.type,
+                #             hgvs_refreshed_variant.posedit.pos,
+                #             hgvs_refreshed_variant.posedit.edit.ref,'')
 
         return hgvs_refreshed_variant
 

--- a/VariantValidator/modules/mappers.py
+++ b/VariantValidator/modules/mappers.py
@@ -770,7 +770,6 @@ def transcripts_to_gene(variant, validator, select_transcripts_dict_plus_version
                 hgvs_coding = new_hgvs_coding
             hgvs_genomic = new_hgvs_genomic
 
-
     # OBTAIN THE RefSeqGene coordinates
     # Attempt 1 = UTA
     sequences_for_tx = variant.map_dat.mapping_options(hgvs_coding.ac)
@@ -1046,12 +1045,54 @@ def final_tx_to_multiple_genomic(variant, validator, tx_variant, liftover_level=
             hgvs_alt_genomic = validator.myvm_t_to_g(variant.hgvs_coding, alt_chr, variant.no_norm_evm,
                                                      variant.hn, variant.map_dat)
 
+            # --- Gap Mapping Final ---
             # Loop out gap code under these circumstances!
             if variant.map_dat.is_gapped_map(variant.hgvs_coding.ac,hgvs_alt_genomic.ac,validator):
                 # warn on gap_compensation for
                 gap_mapper = gapped_mapping.GapMapper(variant, validator)
                 hgvs_alt_genomic, hgvs_coding = gap_mapper.g_to_t_gap_compensation_version3(
                     hgvs_alt_genomic, variant.hgvs_coding, ori, alt_chr, rec_var)
+
+                # Update gap warnings
+                if "Submitted description does not represent" not in str(variant.warnings):
+
+                    # Check assembly
+                    if "NC_" in hgvs_alt_genomic.ac and seq_data.to_chr_num_refseq(hgvs_alt_genomic.ac, variant.primary_assembly) is not None:
+                        make_gap_warnings = gap_mapper.make_gap_warnings(hgvs_coding.ac, hgvs_alt_genomic.ac, variant.primary_assembly)
+                        make_gap_warnings["gapped_alignment_warning"] = make_gap_warnings[
+                            "gapped_alignment_warning"].replace(
+                            "Submitted description does not represent a true variant because it is an artefact of aligning",
+                            "GappedAlignmentWarning: Variation described in the context of an imperfect alignment of")
+                        variant.warnings.append(make_gap_warnings["gapped_alignment_warning"])
+                        variant.warnings.append(make_gap_warnings["auto_info"])
+
+                    elif "NC_" in variant.original and ":g." in variant.original:
+                        original_g_ac = variant.original.split(":g.")[0]
+                        if seq_data.to_chr_num_refseq(original_g_ac, variant.primary_assembly) is None:
+                            make_gap_warnings = gap_mapper.make_gap_warnings(hgvs_coding.ac, original_g_ac,
+                                                                             variant.primary_assembly)
+                            make_gap_warnings["gapped_alignment_warning"] = make_gap_warnings[
+                                "gapped_alignment_warning"].replace(
+                                "Submitted description does not represent a true variant because it is an artefact of aligning",
+                                "GappedAlignmentWarning: Variation described in the context of an imperfect alignment of")
+                            variant.warnings.append(make_gap_warnings["gapped_alignment_warning"])
+                            variant.warnings.append(make_gap_warnings["auto_info"])
+
+                    elif match := re.match(r"(?:chr)?\d+[-:]", variant.original, re.IGNORECASE):
+                        chromosome = match.group()
+                        chromosome = chromosome.replace("-", "")
+                        chromosome = chromosome.replace(":", "")
+                        original_g_ac = seq_data.to_accession(chromosome, variant.primary_assembly)
+                        make_gap_warnings = gap_mapper.make_gap_warnings(hgvs_coding.ac, original_g_ac,
+                                                                         variant.primary_assembly)
+                        make_gap_warnings["gapped_alignment_warning"] = make_gap_warnings[
+                            "gapped_alignment_warning"].replace(
+                            "Submitted description does not represent a true variant because it is an artefact of aligning",
+                            "GappedAlignmentWarning: Variation described in the context of an imperfect alignment of")
+                        variant.warnings.append(make_gap_warnings["gapped_alignment_warning"])
+                        variant.warnings.append(make_gap_warnings["auto_info"])
+
+                # Continue
                 logger.info(f"gap_compensation_3 done for {variant.hgvs_coding} mapped to {hgvs_alt_genomic}")
                 variant.hgvs_coding = hgvs_coding
                 logger.info(f"hgvs_coding updated to {hgvs_coding}")

--- a/VariantValidator/modules/utils.py
+++ b/VariantValidator/modules/utils.py
@@ -959,8 +959,8 @@ WARNING_CODE_MAP = {
     "Mapping unavailable for RefSeqGene":
         ("TranscriptMappingError", None),
 
-    "Transcript ":
-        ("TranscriptDataError", None),
+    # "Transcript ":
+    #     ("TranscriptDataError", None),
 
     "Required information for ":
         ("TranscriptDataError", None),
@@ -1010,6 +1010,15 @@ WARNING_CODE_MAP = {
 
     "Automap is unable to correct the input exon/intron boundary coordinates":
         ("ExonBoundaryError", None),
+
+    "fewer bases between":
+        ("GappedAlignmentWarning", None),
+
+    "extra bases between":
+        ("GappedAlignmentWarning", None),
+
+    "Submitted description does not represent a true variant":
+        ("GappedAlignmentWarning", None),
 
     # ========================================================================
     # Alleles

--- a/VariantValidator/modules/vvMixinCore.py
+++ b/VariantValidator/modules/vvMixinCore.py
@@ -789,10 +789,9 @@ class Mixin(vvMixinConverters.Mixin):
                                  f"website at https://hgvs-nomenclature.org/stable/. For additional assistance "
                                  f"contact us at https://variantvalidator.org/help/contact/")
                         my_variant.warnings.append(error)
-                        exc_type, exc_value, last_traceback = sys.exc_info()
-                        logger.error(str(exc_type) + " " + str(exc_value))
-                        import traceback
-                        traceback.print_exc()
+                        logger.exception(error)
+                        # import traceback
+                        # traceback.print_exc()
                         continue
 
             # Outside the for loop
@@ -1174,11 +1173,8 @@ class Mixin(vvMixinConverters.Mixin):
                                             predicted_protein_variant.format({
                                                 'max_ref_length': 0,
                                                 'p_3_letter':False})
-                                except Exception as e:
-                                    print("AWOOOOOOOOOGA")
-                                    print(predicted_protein_variant)
-                                    import traceback
-                                    traceback.print_exc()
+                                except Exception:
+                                    logger.exception("Unable to format protein variants.")
 
 
                                 # set LRG outputs

--- a/VariantValidator/update_vv_db.py
+++ b/VariantValidator/update_vv_db.py
@@ -125,26 +125,27 @@ def update_refseq(dbcnx):
     grch38 = grch38.decode()
     grch38_align_data = grch38.strip().split('\n')
 
-    # Download data for GRCh37 alignments. Unlike GRCh38, GRCh37 is no longer
-    # updated so we use the fixed GCF_000001405.25_GRCh37.p13 assembly.
-    base_url = (
-        'https://ftp.ncbi.nlm.nih.gov/genomes/refseq/vertebrate_mammalian/'
-        'Homo_sapiens/all_assembly_versions/'
-        'GCF_000001405.25_GRCh37.p13/'
-    )
-
-    ncbi_web_resp = requests.get(base_url)
-    ncbi_web_resp.raise_for_status()
-    ncbi_web_resp = re.findall(r"href=[\"'][^\"']+[\"']", ncbi_web_resp.text)
-    ncbi_web_resp = list(filter(
-        lambda x: 'GCF_000001405.25_GRCh37.p13' in x and '_genomic.gff.gz' in x,
-        ncbi_web_resp))
-
-    grch37 = requests.get(base_url + ncbi_web_resp[0][6:-1])
-    grch37.raise_for_status()
-    grch37 = gzip.decompress(grch37.content)
-    grch37 = grch37.decode()
-    grch37_align_data = grch37.strip().split('\n')
+    # # Download data for GRCh37 alignments. Unlike GRCh38, GRCh37 is no longer
+    # # updated so we use the fixed GCF_000001405.25_GRCh37.p13 assembly.
+    # base_url = (
+    #     'https://ftp.ncbi.nlm.nih.gov/genomes/refseq/vertebrate_mammalian/'
+    #     'Homo_sapiens/all_assembly_versions/'
+    #     'GCF_000001405.25_GRCh37.p13/'
+    # )
+    #
+    # ncbi_web_resp = requests.get(base_url)
+    # ncbi_web_resp.raise_for_status()
+    # ncbi_web_resp = re.findall(r"href=[\"'][^\"']+[\"']", ncbi_web_resp.text)
+    # ncbi_web_resp = list(filter(
+    #     lambda x: 'GCF_000001405.25_GRCh37.p13' in x and '_genomic.gff.gz' in x,
+    #     ncbi_web_resp))
+    #
+    # grch37 = requests.get(base_url + ncbi_web_resp[0][6:-1])
+    # grch37.raise_for_status()
+    # grch37 = gzip.decompress(grch37.content)
+    # grch37 = grch37.decode()
+    # grch37_align_data = grch37.strip().split('\n')
+    grch37_align_data = []
 
     # Open Lists
     # rsg_data = open(os.path.join(ROOT, 'gene_RefSeqGene'), 'r')

--- a/tests/test_expanded_repeats.py
+++ b/tests/test_expanded_repeats.py
@@ -418,10 +418,7 @@ class TestCVariantsExpanded(TestCase):
         print(results)
         assert results["NM_002111.8:c.54_116GCA[21]"]["primary_assembly_loci"]["grch37"][
             "hgvs_genomic_description"] == "NC_000004.11:g.3076606_3076662GCA[21]"
-        assert results["NM_002111.8:c.54_116GCA[21]"]["validation_warnings"] ==  [
-            "ExpandedRepeatError: The coordinates for the repeat region are stated incorrectly in the submitted description NM_002111.8:c.54GCA[21]. The corrected description is NM_002111.8:c.54_116GCA[21]",
-            "ExpandedRepeatWarning: NM_002111.8:c.54_116GCA[21] should only be used as an annotation for the core HGVS descriptions provided"
-        ]
+        assert results["NM_002111.8:c.54_116GCA[21]"]["validation_warnings"] ==  ['ExpandedRepeatError: The coordinates for the repeat region are stated incorrectly in the submitted description NM_002111.8:c.54GCA[21]. The corrected description is NM_002111.8:c.54_116GCA[21]', 'ExpandedRepeatWarning: NM_002111.8:c.54_116GCA[21] should only be used as an annotation for the core HGVS descriptions provided', 'GappedAlignmentWarning: Variation described in the context of an imperfect alignment of NM_002111.8 with NC_000004.11 (genome build GRCh37)', 'GappedAlignmentWarning: NM_002111.8 contains 6 extra bases between c.51_58 than NC_000004.11']
 
     def test_antisense_intron_range(self):
         variant = 'NM_000088.3:c.589-1_590G[3]'
@@ -735,10 +732,10 @@ class TestTranscriptVariantsExpandedNvsC(TestCase):
         print(results)
         assert results["validation_warning_1"]["validation_warnings"] == [
             'RepeatSyntaxError: The provided repeat sequence T does not match the reference '
-            'sequence C at the given position 2_2 of reference sequence NM_022167.4'
+            'sequence C at the given position 4_4 of reference sequence NM_022167.4'
         ]
 
-    def test_5_utr_single_pos_incorrect_c(self):
+    def test_5_utr_single_pos_incorrect_c1(self):
         variant = 'NM_022167.4:c.-13T[3]'
         results = self.vv.validate(variant, 'GRCh37', 'all').format_as_dict(test=True)
         print(results)
@@ -1361,10 +1358,7 @@ class TestExpandedRepeaLocusReferenceGenomic(TestCase):
         print(results)
         assert results["NM_002111.8:c.54_116GCA[21]"]["primary_assembly_loci"]["grch37"][
             "hgvs_genomic_description"] == "NC_000004.11:g.3076606_3076662GCA[21]"
-        assert results["NM_002111.8:c.54_116GCA[21]"]["validation_warnings"] ==   [
-            "ExpandedRepeatError: The coordinates for the repeat region are stated incorrectly in the submitted description LRG_763t1:c.54GCA[21]. The corrected description is NM_002111.8:c.54_116GCA[21]",
-            "ExpandedRepeatWarning: NM_002111.8:c.54_116GCA[21] should only be used as an annotation for the core HGVS descriptions provided"
-        ]
+        assert results["NM_002111.8:c.54_116GCA[21]"]["validation_warnings"] ==    ['ExpandedRepeatError: The coordinates for the repeat region are stated incorrectly in the submitted description LRG_763t1:c.54GCA[21]. The corrected description is NM_002111.8:c.54_116GCA[21]', 'ExpandedRepeatWarning: NM_002111.8:c.54_116GCA[21] should only be used as an annotation for the core HGVS descriptions provided', 'GappedAlignmentWarning: Variation described in the context of an imperfect alignment of NM_002111.8 with NC_000004.11 (genome build GRCh37)', 'GappedAlignmentWarning: NM_002111.8 contains 6 extra bases between c.51_58 than NC_000004.11']
 
 
 if __name__ == "__main__":

--- a/tests/test_variantformatter_inputs.py
+++ b/tests/test_variantformatter_inputs.py
@@ -19,7 +19,7 @@ class TestVFvariantsAuto(object):
         assert 'NC_000019.10:g.50378563_50378564insTAC' in results.keys()
         assert results['NC_000019.10:g.50378563_50378564insTAC']['p_vcf'] is None
         assert results['NC_000019.10:g.50378563_50378564insTAC']['g_hgvs'] is None
-        assert results['NC_000019.10:g.50378563_50378564insTAC']['genomic_variant_error'] == 'chromosome ID NC_000019.10 is not associated with genome build GRCh37'
+        assert results['NC_000019.10:g.50378563_50378564insTAC']['genomic_variant_error'] == 'GenomeReferenceWarning: Chromosome ID NC_000019.10 is not associated with genome build GRCh37'
         assert results['NC_000019.10:g.50378563_50378564insTAC']['hgvs_t_and_p'] is None
 
     def test_variant2(self):
@@ -30,7 +30,7 @@ class TestVFvariantsAuto(object):
         assert '11-5248232-A-T' in results.keys()
         assert results['11-5248232-A-T']['p_vcf'] is None
         assert results['11-5248232-A-T']['g_hgvs'] is None
-        assert results['11-5248232-A-T']['genomic_variant_error'] == 'NC_000011.9:g.5248232A>T: Variant reference (A) does not agree with reference sequence (T)'
+        assert results['11-5248232-A-T']['genomic_variant_error'] == 'ReferenceMismatchError: NC_000011.9:g.5248232A>T: Variant reference (A) does not agree with reference sequence (T)'
         assert results['11-5248232-A-T']['hgvs_t_and_p'] is None
 
     def test_variant3(self):
@@ -6667,7 +6667,7 @@ class TestVFvariantsAuto(object):
         assert '14-105246588-TCT-T' in results.keys()
         assert results['14-105246588-TCT-T']['p_vcf'] is None
         assert results['14-105246588-TCT-T']['g_hgvs'] is None
-        assert results['14-105246588-TCT-T']['genomic_variant_error'] == 'NC_000014.9:g.105246588_105246590delTCTinsT: Variant reference (TCT) does not agree with reference sequence (GCC)'
+        assert results['14-105246588-TCT-T']['genomic_variant_error'] == 'ReferenceMismatchError: NC_000014.9:g.105246588_105246590delTCTinsT: Variant reference (TCT) does not agree with reference sequence (GCC)'
         assert results['14-105246588-TCT-T']['hgvs_t_and_p'] is None
 
     def test_variant239(self):

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -915,28 +915,28 @@ class TestVFGapWarnings(TestCase):
                                                                  'GRCh37', 'refseq', None, False, True, testing=True)
         print(results)
         assert 'NC_000017.10:g.5286863_5286889AGTGTTTGGAATTTTCTGTTCATATAG=' in results.keys()
-        assert 'NM_001083585.1 contains 25 fewer bases between c.*344_*345 than NC_000017.10' in results[
+        assert 'GappedAlignmentWarning: NM_001083585.1 contains 25 fewer bases between c.*344_*345 than NC_000017.10' in results[
             'NC_000017.10:g.5286863_5286889AGTGTTTGGAATTTTCTGTTCATATAG=']['NC_000017.10:g.5286863_5286889AGTGTTTGGAATTTTCTGTTCATATAG=']['hgvs_t_and_p'][
             'NM_001083585.1']['gap_statement']
-        assert 'NM_001083585.2 contains 25 fewer bases between c.*344_*345 than NC_000017.10' in results[
+        assert 'GappedAlignmentWarning: NM_001083585.2 contains 25 fewer bases between c.*344_*345 than NC_000017.10' in results[
             'NC_000017.10:g.5286863_5286889AGTGTTTGGAATTTTCTGTTCATATAG=']['NC_000017.10:g.5286863_5286889AGTGTTTGGAATTTTCTGTTCATATAG=']['hgvs_t_and_p'][
             'NM_001083585.2']['gap_statement']
-        assert 'NM_001083585.3 contains 25 fewer bases between c.*369_*370 than NC_000017.10' in results[
+        assert 'GappedAlignmentWarning: NM_001083585.3 contains 25 fewer bases between c.*369_*370 than NC_000017.10' in results[
             'NC_000017.10:g.5286863_5286889AGTGTTTGGAATTTTCTGTTCATATAG=']['NC_000017.10:g.5286863_5286889AGTGTTTGGAATTTTCTGTTCATATAG=']['hgvs_t_and_p'][
             'NM_001083585.3']['gap_statement']
-        assert 'NM_001291581.1 contains 25 fewer bases between c.*344_*345 than NC_000017.10' in results[
+        assert 'GappedAlignmentWarning: NM_001291581.1 contains 25 fewer bases between c.*344_*345 than NC_000017.10' in results[
             'NC_000017.10:g.5286863_5286889AGTGTTTGGAATTTTCTGTTCATATAG=']['NC_000017.10:g.5286863_5286889AGTGTTTGGAATTTTCTGTTCATATAG=']['hgvs_t_and_p'][
             'NM_001291581.1']['gap_statement']
-        assert 'NM_001291581.2 contains 25 fewer bases between c.*369_*370 than NC_000017.10' in results[
+        assert 'GappedAlignmentWarning: NM_001291581.2 contains 25 fewer bases between c.*369_*370 than NC_000017.10' in results[
             'NC_000017.10:g.5286863_5286889AGTGTTTGGAATTTTCTGTTCATATAG=']['NC_000017.10:g.5286863_5286889AGTGTTTGGAATTTTCTGTTCATATAG=']['hgvs_t_and_p'][
             'NM_001291581.2']['gap_statement']
-        assert 'NM_004703.4 contains 25 fewer bases between c.*344_*345 than NC_000017.10' in results[
+        assert 'GappedAlignmentWarning: NM_004703.4 contains 25 fewer bases between c.*344_*345 than NC_000017.10' in results[
             'NC_000017.10:g.5286863_5286889AGTGTTTGGAATTTTCTGTTCATATAG=']['NC_000017.10:g.5286863_5286889AGTGTTTGGAATTTTCTGTTCATATAG=']['hgvs_t_and_p'][
             'NM_004703.4']['gap_statement']
-        assert 'NM_004703.5 contains 25 fewer bases between c.*344_*345 than NC_000017.10' in results[
+        assert 'GappedAlignmentWarning: NM_004703.5 contains 25 fewer bases between c.*344_*345 than NC_000017.10' in results[
             'NC_000017.10:g.5286863_5286889AGTGTTTGGAATTTTCTGTTCATATAG=']['NC_000017.10:g.5286863_5286889AGTGTTTGGAATTTTCTGTTCATATAG=']['hgvs_t_and_p'][
             'NM_004703.5']['gap_statement']
-        assert 'NM_004703.6 contains 25 fewer bases between c.*369_*370 than NC_000017.10' in results[
+        assert 'GappedAlignmentWarning: NM_004703.6 contains 25 fewer bases between c.*369_*370 than NC_000017.10' in results[
             'NC_000017.10:g.5286863_5286889AGTGTTTGGAATTTTCTGTTCATATAG=']['NC_000017.10:g.5286863_5286889AGTGTTTGGAATTTTCTGTTCATATAG=']['hgvs_t_and_p'][
             'NM_004703.6']['gap_statement']
 
@@ -945,34 +945,44 @@ class TestVFGapWarnings(TestCase):
                                                                  'GRCh37', 'refseq', None, False, True, testing=True)
         print(results)
         assert 'NC_000012.11:g.122064777C>A' in results.keys()
-        assert 'NM_032790.3 contains 6 fewer bases between c.126_127 than NC_000012.11' in results[
+        assert 'GappedAlignmentWarning: NM_032790.3 contains 6 fewer bases between c.126_127 than NC_000012.11' in results[
             'NC_000012.11:g.122064777C>A']['NC_000012.11:g.122064777C>A']['hgvs_t_and_p'][
             'NM_032790.3']['gap_statement']
+
+    def test_vf_series_6a_regression(self):
+        results = simpleVariantFormatter.format('NC_000012.11:g.122064700del',
+                                                                 'GRCh37', 'refseq', None, False, True, testing=True)
+        print(results)
+        assert results['NC_000012.11:g.122064700del']["NC_000012.11:g.122064700del"]['hgvs_t_and_p'][
+            'NM_032790.4']['gap_statement'] == "GappedAlignmentWarning: NM_032790.4 contains 6 fewer bases between c.137_138 than NC_000012.11"
+        assert results['NC_000012.11:g.122064700del']["NC_000012.11:g.122064700del"]['hgvs_t_and_p'][
+            'NM_032790.4']['gapped_alignment_warning'] == "GappedAlignmentWarning: Variation described in the context of an imperfect alignment of NM_032790.4 with NC_000012.11 (genome build GRCh37)"
+
 
     def test_vf_series_7(self):
         results = simpleVariantFormatter.format('NC_000002.11:g.95847041_95847043GCG=',
                                                                  'GRCh37', 'refseq', None, False, True, testing=True)
         print(results)
         assert 'NC_000002.11:g.95847041_95847043GCG=' in results.keys()
-        assert 'NM_001017396.1 contains 3 fewer bases between c.341_342 than NC_000002.11' in results[
+        assert 'GappedAlignmentWarning: NM_001017396.1 contains 3 fewer bases between c.341_342 than NC_000002.11' in results[
             'NC_000002.11:g.95847041_95847043GCG=']['NC_000002.11:g.95847041_95847043GCG=']['hgvs_t_and_p'][
             'NM_001017396.1']['gap_statement']
-        assert 'NM_001017396.2 contains 3 fewer bases between c.341_342 than NC_000002.11' in results[
+        assert 'GappedAlignmentWarning: NM_001017396.2 contains 3 fewer bases between c.341_342 than NC_000002.11' in results[
             'NC_000002.11:g.95847041_95847043GCG=']['NC_000002.11:g.95847041_95847043GCG=']['hgvs_t_and_p'][
             'NM_001017396.2']['gap_statement']
-        assert 'NM_001282398.1 contains 3 fewer bases between c.353_354 than NC_000002.11' in results[
+        assert 'GappedAlignmentWarning: NM_001282398.1 contains 3 fewer bases between c.353_354 than NC_000002.11' in results[
             'NC_000002.11:g.95847041_95847043GCG=']['NC_000002.11:g.95847041_95847043GCG=']['hgvs_t_and_p'][
             'NM_001282398.1']['gap_statement']
-        assert 'NM_001291604.1 contains 3 fewer bases between c.227_228 than NC_000002.11' in results[
+        assert 'GappedAlignmentWarning: NM_001291604.1 contains 3 fewer bases between c.227_228 than NC_000002.11' in results[
             'NC_000002.11:g.95847041_95847043GCG=']['NC_000002.11:g.95847041_95847043GCG=']['hgvs_t_and_p'][
             'NM_001291604.1']['gap_statement']
-        assert 'NM_001291605.1 contains 3 fewer bases between c.506_507 than NC_000002.11' in results[
+        assert 'GappedAlignmentWarning: NM_001291605.1 contains 3 fewer bases between c.506_507 than NC_000002.11' in results[
             'NC_000002.11:g.95847041_95847043GCG=']['NC_000002.11:g.95847041_95847043GCG=']['hgvs_t_and_p'][
             'NM_001291605.1']['gap_statement']
-        assert 'NM_021088.2 contains 3 fewer bases between c.467_468 than NC_000002.11' in results[
+        assert 'GappedAlignmentWarning: NM_021088.2 contains 3 fewer bases between c.467_468 than NC_000002.11' in results[
             'NC_000002.11:g.95847041_95847043GCG=']['NC_000002.11:g.95847041_95847043GCG=']['hgvs_t_and_p'][
             'NM_021088.2']['gap_statement']
-        assert 'NM_021088.3 contains 3 fewer bases between c.467_468 than NC_000002.11' in results[
+        assert 'GappedAlignmentWarning: NM_021088.3 contains 3 fewer bases between c.467_468 than NC_000002.11' in results[
             'NC_000002.11:g.95847041_95847043GCG=']['NC_000002.11:g.95847041_95847043GCG=']['hgvs_t_and_p'][
             'NM_021088.3']['gap_statement']
 
@@ -980,13 +990,13 @@ class TestVFGapWarnings(TestCase):
         results = simpleVariantFormatter.format('NC_000003.11:g.14561629_14561630insG',
                                                 'GRCh37', 'refseq', None, False, True, testing=True)
         print(results)
-        assert 'NM_001080423.2 contains 1 extra bases between c.1308_1310 than NC_000003.11' in results[
+        assert 'GappedAlignmentWarning: NM_001080423.2 contains 1 extra bases between c.1308_1310 than NC_000003.11' in results[
             'NC_000003.11:g.14561629_14561630insG']['NC_000003.11:g.14561629_14561630insG']['hgvs_t_and_p'][
             'NM_001080423.2']['gap_statement']
-        assert 'NM_001080423.3 contains 1 extra bases between c.1017_1019 than NC_000003.11' in results[
+        assert 'GappedAlignmentWarning: NM_001080423.3 contains 1 extra bases between c.1017_1019 than NC_000003.11' in results[
             'NC_000003.11:g.14561629_14561630insG']['NC_000003.11:g.14561629_14561630insG']['hgvs_t_and_p'][
             'NM_001080423.3']['gap_statement']
-        assert 'NM_001080423.4 contains 1 extra bases between c.1019_1021 than NC_000003.11' in results[
+        assert 'GappedAlignmentWarning: NM_001080423.4 contains 1 extra bases between c.1019_1021 than NC_000003.11' in results[
             'NC_000003.11:g.14561629_14561630insG']['NC_000003.11:g.14561629_14561630insG']['hgvs_t_and_p'][
             'NM_001080423.4']['gap_statement']
 
@@ -995,7 +1005,7 @@ class TestVFGapWarnings(TestCase):
                                                 'GRCh37', 'refseq', None, False, True, testing=True)
         print(results)
         assert 'NC_000004.11:g.140811117C>A' in results.keys()
-        assert 'NM_018717.4 contains 3 fewer bases between c.2276_2277, and 12 fewer bases between c.1467_1468 ' \
+        assert 'GappedAlignmentWarning: NM_018717.4 contains 3 fewer bases between c.2276_2277, and 12 fewer bases between c.1467_1468 ' \
                'than NC_000004.11' in results[
             'NC_000004.11:g.140811117C>A']['NC_000004.11:g.140811117C>A']['hgvs_t_and_p'][
             'NM_018717.4']['gap_statement']
@@ -1005,10 +1015,10 @@ class TestVFGapWarnings(TestCase):
                                                 'GRCh37', 'refseq', None, False, True, testing=True)
         print(results)
         assert 'NC_000009.11:g.136132908_136132909TA=' in results.keys()
-        assert 'NM_020469.2 contains 1 extra bases between c.260_262 than NC_000009.11' in results[
+        assert 'GappedAlignmentWarning: NM_020469.2 contains 1 extra bases between c.260_262 than NC_000009.11' in results[
             'NC_000009.11:g.136132908_136132909TA=']['NC_000009.11:g.136132908_136132909TA=']['hgvs_t_and_p'][
             'NM_020469.2']['gap_statement']
-        assert 'NM_020469.3 contains 22 extra bases between c.*756_*757, and 2 extra bases between c.*797_*798, ' \
+        assert 'GappedAlignmentWarning: NM_020469.3 contains 22 extra bases between c.*756_*757, and 2 extra bases between c.*797_*798, ' \
                'and 110 extra bases between c.*840_*841, and 2 extra bases between c.*4648_*4649, and 1 extra ' \
                'bases between c.260_262 than NC_000009.11' in results[
             'NC_000009.11:g.136132908_136132909TA=']['NC_000009.11:g.136132908_136132909TA=']['hgvs_t_and_p'][
@@ -1058,145 +1068,159 @@ class TestVVGapWarnings(TestCase):
         variant = 'NC_000004.11:g.140811117C>A'
         results = self.vv.validate(variant, 'GRCh37', 'all').format_as_dict(test=True)
         print(results)
-        assert "NM_018717.4 contains 3 fewer bases between c.2276_2277, and 12 fewer bases between c.1467_1468 than NC_000004.11" in \
+        assert "GappedAlignmentWarning: NM_018717.4 contains 3 fewer bases between c.2276_2277, and 12 fewer bases between c.1467_1468 than NC_000004.11" in \
                results['NM_018717.4:c.1472_1473insTCAGCAGCAGCA']['validation_warnings']
 
     def test_vv_series_2(self):
         variant = 'NC_000008.10:g.24811072C>T'
         results = self.vv.validate(variant, 'GRCh37', 'all').format_as_dict(test=True)
         print(results)
-        assert "NM_006158.5 contains 1 fewer bases between c.1413_1414 than NC_000008.10" in \
+        assert "GappedAlignmentWarning: NM_006158.5 contains 1 fewer bases between c.1413_1414 than NC_000008.10" in \
                results['NM_006158.5:c.1407delinsAC']['validation_warnings']
-        assert "NM_006158.4 contains 1 fewer bases between c.1407_1408 than NC_000008.10" in \
+        assert "GappedAlignmentWarning: NM_006158.4 contains 1 fewer bases between c.1407_1408 than NC_000008.10" in \
                results['NM_006158.4:c.1407delinsAC']['validation_warnings']
-        assert "NM_006158.3 contains 1 fewer bases between c.1407_1408 than NC_000008.10" in \
+        assert "GappedAlignmentWarning: NM_006158.3 contains 1 fewer bases between c.1407_1408 than NC_000008.10" in \
                results['NM_006158.3:c.1407delinsAC']['validation_warnings']
 
     def test_vv_series_3(self):
         variant = 'NC_000015.9:g.72105933del'
         results = self.vv.validate(variant, 'GRCh37', 'all').format_as_dict(test=True)
         print(results)
-        assert "NM_016346.4 contains 1 fewer bases between c.951_952 than NC_000015.9" in \
+        assert "GappedAlignmentWarning: NM_016346.4 contains 1 fewer bases between c.951_952 than NC_000015.9" in \
                results['NM_016346.4:c.951_952=']['validation_warnings']
-        assert "NM_016346.3 contains 1 fewer bases between c.947_948 than NC_000015.9" in \
+        assert "GappedAlignmentWarning: NM_016346.3 contains 1 fewer bases between c.947_948 than NC_000015.9" in \
                results['NM_016346.3:c.947_948=']['validation_warnings']
-        assert "NM_016346.2 contains 1 fewer bases between c.947_948 than NC_000015.9" in \
+        assert "GappedAlignmentWarning: NM_016346.2 contains 1 fewer bases between c.947_948 than NC_000015.9" in \
                results['NM_016346.2:c.947_948=']['validation_warnings']
-        assert "NM_014249.4 contains 1 fewer bases between c.951_952 than NC_000015.9" in \
+        assert "GappedAlignmentWarning: NM_014249.4 contains 1 fewer bases between c.951_952 than NC_000015.9" in \
                results['NM_014249.4:c.951_952=']['validation_warnings']
-        assert "NM_014249.3 contains 1 fewer bases between c.947_948 than NC_000015.9" in \
+        assert "GappedAlignmentWarning: NM_014249.3 contains 1 fewer bases between c.947_948 than NC_000015.9" in \
                results['NM_014249.3:c.947_948=']['validation_warnings']
-        assert "NM_014249.2 contains 1 fewer bases between c.947_948 than NC_000015.9" in \
+        assert "GappedAlignmentWarning: NM_014249.2 contains 1 fewer bases between c.947_948 than NC_000015.9" in \
                results['NM_014249.2:c.947_948=']['validation_warnings']
+
+    def test_vv_regression_gap_warning_on_gap_miss_1(self):
+        variant = "NM_016346.4:c.900del"
+        results = self.vv.validate(variant, 'GRCh37', 'all').format_as_dict(test=True)
+        assert results['NM_016346.4:c.900del']['validation_warnings'] == [
+            "GappedAlignmentWarning: Variation described in the context of an imperfect alignment of NM_016346.4 with NC_000015.9 (genome build GRCh37)",
+            "GappedAlignmentWarning: NM_016346.4 contains 1 fewer bases between c.951_952 than NC_000015.9"
+        ]
+        variant = "NC_000015.9:g.72105881del"
+        results = self.vv.validate(variant, 'GRCh37', 'NM_016346.4').format_as_dict(test=True)
+        assert results['NM_016346.4:c.900del']['validation_warnings'] == [
+            "GappedAlignmentWarning: Variation described in the context of an imperfect alignment of NM_016346.4 with NC_000015.9 (genome build GRCh37)",
+            "GappedAlignmentWarning: NM_016346.4 contains 1 fewer bases between c.951_952 than NC_000015.9"
+        ]
 
     def test_vv_series_4(self):
         variant = 'NC_000019.9:g.41123095dup'
         results = self.vv.validate(variant, 'GRCh37', 'all').format_as_dict(test=True)
         print(results)
-        assert "NM_003573.2 contains 1 extra bases between c.3122_3124 than NC_000019.9" in \
+        assert "GappedAlignmentWarning: NM_003573.2 contains 1 extra bases between c.3122_3124 than NC_000019.9" in \
                results['NM_003573.2:c.3122_3124=']['validation_warnings']
-        assert "NM_001042545.2 contains 1 extra bases between c.3034_3036 than NC_000019.9" in \
+        assert "GappedAlignmentWarning: NM_001042545.2 contains 1 extra bases between c.3034_3036 than NC_000019.9" in \
                results['NM_001042545.2:c.3033_3036=']['validation_warnings']
-        assert "NM_001042545.1 contains 1 extra bases between c.3032_3034 than NC_000019.9" in \
+        assert "GappedAlignmentWarning: NM_001042545.1 contains 1 extra bases between c.3032_3034 than NC_000019.9" in \
                results['NM_001042545.1:c.3032_3034=']['validation_warnings']
-        assert "NM_001042544.1 contains 1 extra bases between c.3233_3235 than NC_000019.9" in \
+        assert "GappedAlignmentWarning: NM_001042544.1 contains 1 extra bases between c.3233_3235 than NC_000019.9" in \
                results['NM_001042544.1:c.3233_3235=']['validation_warnings']
 
     def test_vv_series_5(self):
         variant = 'NC_000017.10:g.5286863_5286889AGTGTTTGGAATTTTCTGTTCATATAG='
         results = self.vv.validate(variant, 'GRCh37', 'all').format_as_dict(test=True)
         print(results)
-        assert "NM_004703.6 contains 25 fewer bases between c.*369_*370 than NC_000017.10" in \
+        assert "GappedAlignmentWarning: NM_004703.6 contains 25 fewer bases between c.*369_*370 than NC_000017.10" in \
                results['NM_004703.6:c.*344_*368dup']['validation_warnings']
-        assert "NM_004703.5 contains 25 fewer bases between c.*344_*345 than NC_000017.10" in \
+        assert "GappedAlignmentWarning: NM_004703.5 contains 25 fewer bases between c.*344_*345 than NC_000017.10" in \
                results['NM_004703.5:c.*344_*368dup']['validation_warnings']
-        assert "NM_004703.4 contains 25 fewer bases between c.*344_*345 than NC_000017.10" in \
+        assert "GappedAlignmentWarning: NM_004703.4 contains 25 fewer bases between c.*344_*345 than NC_000017.10" in \
                results['NM_004703.4:c.*344_*368dup']['validation_warnings']
-        assert "NM_001291581.2 contains 25 fewer bases between c.*369_*370 than NC_000017.10" in \
+        assert "GappedAlignmentWarning: NM_001291581.2 contains 25 fewer bases between c.*369_*370 than NC_000017.10" in \
                results['NM_001291581.2:c.*344_*368dup']['validation_warnings']
-        assert "NM_001291581.1 contains 25 fewer bases between c.*344_*345 than NC_000017.10" in \
+        assert "GappedAlignmentWarning: NM_001291581.1 contains 25 fewer bases between c.*344_*345 than NC_000017.10" in \
                results['NM_001291581.1:c.*344_*368dup']['validation_warnings']
-        assert "NM_001083585.3 contains 25 fewer bases between c.*369_*370 than NC_000017.10" in \
+        assert "GappedAlignmentWarning: NM_001083585.3 contains 25 fewer bases between c.*369_*370 than NC_000017.10" in \
                results['NM_001083585.3:c.*344_*368dup']['validation_warnings']
-        assert "NM_001083585.2 contains 25 fewer bases between c.*344_*345 than NC_000017.10" in \
+        assert "GappedAlignmentWarning: NM_001083585.2 contains 25 fewer bases between c.*344_*345 than NC_000017.10" in \
                results['NM_001083585.2:c.*344_*368dup']['validation_warnings']
-        assert "NM_001083585.1 contains 25 fewer bases between c.*344_*345 than NC_000017.10" in \
+        assert "GappedAlignmentWarning: NM_001083585.1 contains 25 fewer bases between c.*344_*345 than NC_000017.10" in \
                results['NM_001083585.1:c.*344_*368dup']['validation_warnings']
 
     def test_vv_series_6(self):
         variant = 'NC_000012.11:g.122064777C>A'
         results = self.vv.validate(variant, 'GRCh37', 'all').format_as_dict(test=True)
         print(results)
-        assert "NM_032790.3 contains 6 fewer bases between c.126_127 than NC_000012.11" in \
+        assert "GappedAlignmentWarning: NM_032790.3 contains 6 fewer bases between c.126_127 than NC_000012.11" in \
                results['NM_032790.3:c.129_130insACACCG']['validation_warnings']
 
     def test_vv_series_7(self):
         variant = 'NC_000002.11:g.95847041_95847043GCG='
         results = self.vv.validate(variant, 'GRCh37', 'all').format_as_dict(test=True)
         print(results)
-        assert "NM_021088.3 contains 3 fewer bases between c.467_468 than NC_000002.11" in \
+        assert "GappedAlignmentWarning: NM_021088.3 contains 3 fewer bases between c.467_468 than NC_000002.11" in \
                results['NM_021088.3:c.471_473dup']['validation_warnings']
-        assert "NM_021088.2 contains 3 fewer bases between c.467_468 than NC_000002.11" in \
+        assert "GappedAlignmentWarning: NM_021088.2 contains 3 fewer bases between c.467_468 than NC_000002.11" in \
                results['NM_021088.2:c.471_473dup']['validation_warnings']
-        assert "NM_001291605.1 contains 3 fewer bases between c.506_507 than NC_000002.11" in \
+        assert "GappedAlignmentWarning: NM_001291605.1 contains 3 fewer bases between c.506_507 than NC_000002.11" in \
                results['NM_001291605.1:c.510_512dup']['validation_warnings']
-        assert "NM_001291604.1 contains 3 fewer bases between c.227_228 than NC_000002.11" in \
+        assert "GappedAlignmentWarning: NM_001291604.1 contains 3 fewer bases between c.227_228 than NC_000002.11" in \
                results['NM_001291604.1:c.231_233dup']['validation_warnings']
-        assert "NM_001282398.1 contains 3 fewer bases between c.353_354 than NC_000002.11" in \
+        assert "GappedAlignmentWarning: NM_001282398.1 contains 3 fewer bases between c.353_354 than NC_000002.11" in \
                results['NM_001282398.1:c.357_359dup']['validation_warnings']
-        assert "NM_001017396.2 contains 3 fewer bases between c.341_342 than NC_000002.11" in \
+        assert "GappedAlignmentWarning: NM_001017396.2 contains 3 fewer bases between c.341_342 than NC_000002.11" in \
                results['NM_001017396.2:c.345_347dup']['validation_warnings']
-        assert "NM_001017396.1 contains 3 fewer bases between c.341_342 than NC_000002.11" in \
+        assert "GappedAlignmentWarning: NM_001017396.1 contains 3 fewer bases between c.341_342 than NC_000002.11" in \
                results['NM_001017396.1:c.345_347dup']['validation_warnings']
 
     def test_vv_series_8(self):
         variant = 'NC_000003.11:g.14561629_14561630insG'
         results = self.vv.validate(variant, 'GRCh37', 'all').format_as_dict(test=True)
         print(results)
-        assert "NM_001080423.4 contains 1 extra bases between c.1019_1021 than NC_000003.11" in \
+        assert "GappedAlignmentWarning: NM_001080423.4 contains 1 extra bases between c.1019_1021 than NC_000003.11" in \
                results['NM_001080423.4:c.1019_1021=']['validation_warnings']
-        assert "NM_001080423.3 contains 1 extra bases between c.1017_1019 than NC_000003.11" in \
+        assert "GappedAlignmentWarning: NM_001080423.3 contains 1 extra bases between c.1017_1019 than NC_000003.11" in \
                results['NM_001080423.3:c.1017_1020=']['validation_warnings']
-        assert "NM_001080423.2 contains 1 extra bases between c.1308_1310 than NC_000003.11" in \
+        assert "GappedAlignmentWarning: NM_001080423.2 contains 1 extra bases between c.1308_1310 than NC_000003.11" in \
                results['NM_001080423.2:c.1308_1311=']['validation_warnings']
 
     def test_vv_series_9(self):
         variant = 'NC_000004.11:g.140811117C>A'
         results = self.vv.validate(variant, 'GRCh37', 'all').format_as_dict(test=True)
         print(results)
-        assert "NM_018717.4 contains 3 fewer bases between c.2276_2277, and 12 fewer bases between c.1467_1468 than NC_000004.11" in \
+        assert "GappedAlignmentWarning: NM_018717.4 contains 3 fewer bases between c.2276_2277, and 12 fewer bases between c.1467_1468 than NC_000004.11" in \
                results['NM_018717.4:c.1472_1473insTCAGCAGCAGCA']['validation_warnings']
 
     def test_vv_series_10(self):
         variant = 'NC_000009.11:g.136132908_136132909TA='
         results = self.vv.validate(variant, 'GRCh37', 'all').format_as_dict(test=True)
         print(results)
-        assert "NM_020469.3 contains 22 extra bases between c.*756_*757, and 2 extra bases between c.*797_*798, and 110 extra bases between c.*840_*841, and 2 extra bases between c.*4648_*4649, and 1 extra bases between c.260_262 than NC_000009.11" in \
+        assert "GappedAlignmentWarning: NM_020469.3 contains 22 extra bases between c.*756_*757, and 2 extra bases between c.*797_*798, and 110 extra bases between c.*840_*841, and 2 extra bases between c.*4648_*4649, and 1 extra bases between c.260_262 than NC_000009.11" in \
                results['NM_020469.3:c.261del']['validation_warnings']
-        assert "NM_020469.2 contains 1 extra bases between c.260_262 than NC_000009.11" in \
+        assert "GappedAlignmentWarning: NM_020469.2 contains 1 extra bases between c.260_262 than NC_000009.11" in \
                results['NM_020469.2:c.261del']['validation_warnings']
 
     def test_vv_series_11(self):
         variant = 'NC_000019.10:g.50378563_50378564insTAC'
         results = self.vv.validate(variant, 'GRCh37', 'all').format_as_dict(test=True)
         print(results)
-        assert "NM_007121.5 contains 3 extra bases between c.514_518 than NC_000019.10" in \
+        assert "GappedAlignmentWarning: NM_007121.5 contains 3 extra bases between c.514_518 than NC_000019.10" in \
                results['NM_007121.5:c.515A>T']['validation_warnings']
-        assert "NM_001256647.1 contains 3 extra bases between c.223_227 than NC_000019.10" in \
+        assert "GappedAlignmentWarning: NM_001256647.1 contains 3 extra bases between c.223_227 than NC_000019.10" in \
                results['NM_001256647.1:c.224A>T']['validation_warnings']
 
     def test_vv_series_12(self):
         variant = 'NC_000007.13:g.149476664_149476666delinsTC'
         results = self.vv.validate(variant, 'GRCh37', 'all').format_as_dict(test=True)
         print(results)
-        assert "NR_163594.1 contains 1 extra bases between n.1129_1131, and 1 fewer bases between n.11675_11676 than NC_000007.13" in \
+        assert "GappedAlignmentWarning: NR_163594.1 contains 1 extra bases between n.1129_1131, and 1 fewer bases between n.11675_11676 than NC_000007.13" in \
                results['NR_163594.1:n.1122_1124delinsT']['validation_warnings']
 
     def test_vv_series_13(self):
         variant = 'NC_000004.12:g.139889957_139889968del'
         results = self.vv.validate(variant, 'GRCh37', 'all').format_as_dict(test=True)
         print(results)
-        assert "NM_018717.4 contains 3 fewer bases between c.2276_2277, and 12 fewer bases between c.1467_1468 than NC_000004.12" in \
+        assert "GappedAlignmentWarning: NM_018717.4 contains 3 fewer bases between c.2276_2277, and 12 fewer bases between c.1467_1468 than NC_000004.12" in \
                results['NM_018717.4:c.1466_1468=']['validation_warnings']
 
     def test_vv_series_14(self):
@@ -1469,12 +1493,7 @@ class TestVVGapWarnings(TestCase):
         variant = 'NM_000088.2:c.589G>T'
         results = self.vv.validate(variant, 'GRCh37', 'all', transcript_set="refseq").format_as_dict(test=True)
         print(results)
-        assert results['NM_000088.2:c.589G>T']['validation_warnings'] ==  [
-            "TranscriptVersionWarning: A more recent version of the selected reference sequence NM_000088.2 is available for genome build GRCh37 (NM_000088.4)",
-            "GenomeReferenceWarning: NM_000088.2:c.589G>T is not part of genome build GRCh37",
-            "GenomeMismatchWarning: NM_000088.2:c.589G>T cannot be mapped directly to genome build GRCh37",
-            "GenomeReferenceWarning: See alternative genomic loci or alternative genome builds for aligned genomic positions"
-        ]
+        assert results['NM_000088.2:c.589G>T']['validation_warnings'] ==  ['TranscriptVersionWarning: A more recent version of the selected reference sequence NM_000088.2 is available for genome build GRCh37 (NM_000088.4)', 'GenomeReferenceWarning: NM_000088.2:c.589G>T is not part of genome build GRCh37', 'GenomeMismatchWarning: NM_000088.2:c.589G>T cannot be mapped directly to genome build GRCh37', 'GenomeReferenceWarning: See alternative genomic loci or alternative genome builds for aligned genomic positions']
 
     def test_old_transcript_version_b(self):
         variant = 'NM_000088.1:c.589G>T'
@@ -1491,13 +1510,41 @@ class TestVVGapWarnings(TestCase):
         print(results)
         assert results[ "NR_046115.2:n.1447_1448insG"]['validation_warnings'] == [
             "ReferenceSequenceError: This is not a valid HGVS variant description, because no reference sequence ID has been provided",
-            "Submitted description does not represent a true variant because it is an artefact of aligning NR_146765.2 with NC_000001.10 (genome build GRCh37)",
-            "NR_046115.2 contains 1 fewer bases between n.1448_1449 than NC_000001.10"
+            "GappedAlignmentWarning: Submitted description does not represent a true variant because it is an artefact of aligning NR_146765.2 with NC_000001.10 (genome build GRCh37)",
+            "GappedAlignmentWarning: NR_046115.2 contains 1 fewer bases between n.1448_1449 than NC_000001.10"
         ]
         assert results["NR_146765.2:n.1649_1650insG"]["validation_warnings"] == [
             "ReferenceSequenceError: This is not a valid HGVS variant description, because no reference sequence ID has been provided",
-            "Submitted description does not represent a true variant because it is an artefact of aligning NR_146765.2 with NC_000001.10 (genome build GRCh37)",
-            "NR_146765.2 contains 1 fewer bases between n.1650_1651 than NC_000001.10"
+            "GappedAlignmentWarning: Submitted description does not represent a true variant because it is an artefact of aligning NR_146765.2 with NC_000001.10 (genome build GRCh37)",
+            "GappedAlignmentWarning: NR_146765.2 contains 1 fewer bases between n.1650_1651 than NC_000001.10"
+        ]
+
+    def test_issue_810_regression_a(self):
+        variant = 'NC_000019.10:g.39911082dup'
+        results = self.vv.validate(variant, 'GRCh38', 'NM_003890.3', transcript_set="refseq").format_as_dict(test=True)
+        print(results)
+        assert results['NM_003890.3:c.4468dup']['validation_warnings'] ==  ['GappedAlignmentWarning: Variation described in the context of an imperfect alignment of NM_003890.3 with NC_000019.10 (genome build GRCh38)', 'GappedAlignmentWarning: NM_003890.3 contains 504 extra bases between c.6504_7009, and 6 fewer bases between c.7037_7038, and 1 fewer bases between c.7046_7047, and 1 fewer bases between c.7061_7062, and 2 fewer bases between c.7066_7067, and 10 extra bases between c.7079_7090, and 1584 extra bases between c.4905_6490, and 2 fewer bases between c.6498_6499, and 414 extra bases between c.4476_4891, and 1 fewer bases between c.4895_4896, and 498 extra bases between c.3969_4468, and 564 extra bases between c.3396_3961, and 3 fewer bases between c.3961_3962 than NC_000019.10']
+
+    def test_issue_810_regression_b(self):
+        variant = 'NC_000019.10:g.39911082dup'
+        results = self.vv.validate(variant, 'GRCh37', 'NM_003890.3', transcript_set="refseq").format_as_dict(test=True)
+        print(results)
+        assert results['NM_003890.3:c.4468dup']['validation_warnings'] ==  ['GappedAlignmentWarning: Variation described in the context of an imperfect alignment of NM_003890.3 with NC_000019.10 (genome build GRCh37)', 'GappedAlignmentWarning: NM_003890.3 contains 504 extra bases between c.6504_7009, and 6 fewer bases between c.7037_7038, and 1 fewer bases between c.7046_7047, and 1 fewer bases between c.7061_7062, and 2 fewer bases between c.7066_7067, and 10 extra bases between c.7079_7090, and 1584 extra bases between c.4905_6490, and 2 fewer bases between c.6498_6499, and 414 extra bases between c.4476_4891, and 1 fewer bases between c.4895_4896, and 498 extra bases between c.3969_4468, and 564 extra bases between c.3396_3961, and 3 fewer bases between c.3961_3962 than NC_000019.10']
+
+    def test_issue_810_regression_c(self):
+        variant = '19-39911082-C-C'
+        results = self.vv.validate(variant, 'GRCh38', 'NM_003890.3', transcript_set="refseq").format_as_dict(test=True)
+        print(results)
+        assert results['NM_003890.3:c.4468=']['validation_warnings'] == ['GappedAlignmentWarning: Variation described in the context of an imperfect alignment of NM_003890.3 with NC_000019.10 (genome build GRCh38)', 'GappedAlignmentWarning: NM_003890.3 contains 504 extra bases between c.6504_7009, and 6 fewer bases between c.7037_7038, and 1 fewer bases between c.7046_7047, and 1 fewer bases between c.7061_7062, and 2 fewer bases between c.7066_7067, and 10 extra bases between c.7079_7090, and 1584 extra bases between c.4905_6490, and 2 fewer bases between c.6498_6499, and 414 extra bases between c.4476_4891, and 1 fewer bases between c.4895_4896, and 498 extra bases between c.3969_4468, and 564 extra bases between c.3396_3961, and 3 fewer bases between c.3961_3962 than NC_000019.10']
+
+    def test_issue_810_regression_d(self):
+        variant = 'chr19:39911082:C:C'
+        results = self.vv.validate(variant, 'GRCh38', 'NM_003890.3', transcript_set="refseq").format_as_dict(test=True)
+        print(results)
+        assert results['NM_003890.3:c.4468=']['validation_warnings'] == [
+            "ReferenceSequenceError: This is not a valid HGVS variant description, because no reference sequence ID has been provided",
+            "GappedAlignmentWarning: Variation described in the context of an imperfect alignment of NM_003890.3 with NC_000019.10 (genome build GRCh38)",
+            "GappedAlignmentWarning: NM_003890.3 contains 504 extra bases between c.6504_7009, and 6 fewer bases between c.7037_7038, and 1 fewer bases between c.7046_7047, and 1 fewer bases between c.7061_7062, and 2 fewer bases between c.7066_7067, and 10 extra bases between c.7079_7090, and 1584 extra bases between c.4905_6490, and 2 fewer bases between c.6498_6499, and 414 extra bases between c.4476_4891, and 1 fewer bases between c.4895_4896, and 498 extra bases between c.3969_4468, and 564 extra bases between c.3396_3961, and 3 fewer bases between c.3961_3962 than NC_000019.10"
         ]
 
 # <LICENSE>


### PR DESCRIPTION
An import was missing from gapped_mapping.py so relevant code was removed as it never ran. Also, GapAlignmentWarning is now added (where possible) to all gapped alignments regardless of whether the variant maps to the gap to alert users that the alignment is suboptimal.